### PR TITLE
added note about external Nautilus server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ You should now be set to run the development server:
 
 Browse to http://localhost:3000/.
 
+Note that, although running Scaife locally, this is relying on the Nautilus server at https://perseus-cts.eu1.eldarioncloud.com to retrieve texts.
+
+
 ## Translations
 
 Before you work with translations, you will need gettext installed.


### PR DESCRIPTION
I didn't want anyone to think it was all local (and offline).