### PR TITLE
sorting options on library page: urn, text group or work

### DIFF
--- a/scaife_viewer/cts/collections.py
+++ b/scaife_viewer/cts/collections.py
@@ -100,16 +100,9 @@ class TextGroup(Collection):
             "works": [
                 {
                     "urn": str(work.urn),
-                    "label": str(work.label),
                     "texts": [
                         {
                             "urn": str(text.urn),
-                            "label": str(text.label),
-                            "description": str(text.description),
-                            "kind": text.kind,
-                            "lang": text.lang,
-                            "rtl": text.rtl,
-                            "human_lang": text.human_lang,
                         }
                         for text in work.texts()
                     ],
@@ -199,9 +192,8 @@ class Text(Collection):
         if chunk is not None:
             return Passage(self, URN(chunk.urn).reference)
 
-    def as_json(self) -> dict:
-        toc = self.toc()
-        return {
+    def as_json(self, with_toc=True) -> dict:
+        payload = {
             "urn": str(self.urn),
             "label": str(self.label),
             "description": str(self.description),
@@ -209,23 +201,28 @@ class Text(Collection):
             "lang": self.lang,
             "rtl": self.rtl,
             "human_lang": self.human_lang,
-            "first_passage": dict(urn=str(self.first_passage().urn)),
-            "ancestors": [
-                {
-                    "urn": str(ancestor.urn),
-                    "label": ancestor.label,
-                }
-                for ancestor in self.ancestors()
-            ],
-            "toc": [
-                {
-                    "urn": next(toc.chunks(ref_node), None).urn,
-                    "label": ref_node.label.title(),
-                    "num": ref_node.num,
-                }
-                for ref_node in toc.num_resolver.glob(toc.root, "*")
-            ],
         }
+        if with_toc:
+            toc = self.toc()
+            payload.update({
+                "first_passage": dict(urn=str(self.first_passage().urn)),
+                "ancestors": [
+                    {
+                        "urn": str(ancestor.urn),
+                        "label": ancestor.label,
+                    }
+                    for ancestor in self.ancestors()
+                ],
+                "toc": [
+                    {
+                        "urn": next(toc.chunks(ref_node), None).urn,
+                        "label": ref_node.label.title(),
+                        "num": ref_node.num,
+                    }
+                    for ref_node in toc.num_resolver.glob(toc.root, "*")
+                ],
+            })
+        return payload
 
 
 def resolve_collection(type_uri):

--- a/scaife_viewer/utils.py
+++ b/scaife_viewer/utils.py
@@ -17,8 +17,8 @@ def link_passage(urn) -> dict:
     }
 
 
-def apify(obj):
-    remaining = obj.as_json()
+def apify(obj, **kwargs):
+    remaining = obj.as_json(**kwargs)
     rels = {}
     if isinstance(obj, cts.TextGroup):
         works = remaining.pop("works")
@@ -30,7 +30,6 @@ def apify(obj):
                     "texts": [
                         {
                             **link_collection(text["urn"]),
-                            "reader_url": reverse("library_text_redirect", kwargs={"urn": text["urn"]}),
                             **text
                         }
                         for text in work["texts"]
@@ -45,16 +44,23 @@ def apify(obj):
             "texts": [{**link_collection(text["urn"]), **text} for text in texts],
         }
     if isinstance(obj, cts.Text):
-        first_passage = remaining.pop("first_passage")
-        ancestors = remaining.pop("ancestors")
-        toc = remaining.pop("toc")
-        rels = {
-            "first_passage": {**link_passage(first_passage["urn"]), **first_passage},
-            "ancestors": [{**link_collection(ancestor["urn"]), **ancestor} for ancestor in ancestors],
-            "toc": [{**link_passage(entry["urn"]), **entry} for entry in toc],
-        }
+        if kwargs.get("with_toc"):
+            first_passage = remaining.pop("first_passage")
+            ancestors = remaining.pop("ancestors")
+            toc = remaining.pop("toc")
+            rels = {
+                "first_passage": {**link_passage(first_passage["urn"]), **first_passage},
+                "ancestors": [{**link_collection(ancestor["urn"]), **ancestor} for ancestor in ancestors],
+                "toc": [{**link_passage(entry["urn"]), **entry} for entry in toc],
+            }
+        else:
+            rels = {}
     if isinstance(obj, cts.Collection):
         links = link_collection(str(obj.urn))
+        if isinstance(obj, cts.Text):
+            links.update({
+                "reader_url": reverse("library_text_redirect", kwargs={"urn": obj.urn}),
+            })
     if isinstance(obj, cts.Passage):
         links = link_passage(str(obj.urn))
         text = remaining.pop("text")

--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -40,9 +40,24 @@ class LibraryView(BaseLibraryView):
         return render(self.request, "library/index.html", {})
 
     def as_json(self):
+        all_text_groups = cts.text_inventory().text_groups()
+
+        text_groups = []
+        works = []
+        texts = []
+
+        for text_group in all_text_groups:
+            for work in text_group.works():
+                works.append(work)
+                for text in work.texts():
+                    texts.append(text)
+            text_groups.append(text_group)
+
         text_groups = self.get_text_groups()
         payload = {
             "text_groups": [apify(text_group) for text_group in text_groups],
+            "works": [apify(work) for work in works],
+            "texts": [apify(text, with_toc=False) for text in texts],
         }
         return JsonResponse(payload)
 

--- a/static/src/js/components/Library.vue
+++ b/static/src/js/components/Library.vue
@@ -73,6 +73,9 @@ export default {
     query() {
       this.filter();
     },
+    sortKind() {
+      this.filter();
+    },
   },
   computed: {
     textGroups() {

--- a/static/src/js/components/Library.vue
+++ b/static/src/js/components/Library.vue
@@ -14,13 +14,18 @@
         </span>
       </div>
     </div>
-    <div class="toggle-all" v-if="!filtered && collapsible">
-      <span @click="expandAll">expand all</span> | <span @click="collapseAll">collapse all</span>
-    </div>
-    <div class="sort">
-      <span @click="sort('cts-urn')" :class="{ active: sortKind === 'cts-urn' }">CTS URN</span> |
-      <span @click="sort('text-group')" :class="{ active: sortKind === 'text-group' }">text group</span> |
-      <span @click="sort('work')" :class="{ active: sortKind === 'work' }">work</span>
+    <div class="controls">
+      <div class="toggle-all">
+        <template v-if="!filtered && collapsible">
+        <span @click="expandAll">expand all</span> | <span @click="collapseAll">collapse all</span>
+        </template>
+      </div>
+      <div class="sort">
+        sort by: 
+        <span @click="sort('cts-urn')" :class="{ active: sortKind === 'cts-urn' }">CTS URN</span> |
+        <span @click="sort('text-group')" :class="{ active: sortKind === 'text-group' }">text group</span> |
+        <span @click="sort('work')" :class="{ active: sortKind === 'work' }">work</span>
+      </div>
     </div>
     <template v-if="loading">
       <div class="text-center">
@@ -35,7 +40,7 @@
           </keep-alive>
         </template>
       </template>
-      <div v-else-if="sortKind === 'work'" class="works">
+      <div v-else-if="sortKind === 'work'" class="flat-work-list">
         <template v-for="work in works">
           <keep-alive>
             <library-work :work="work" :filtered="filtered" :key="work.urn" />

--- a/static/src/js/components/LibraryWork.vue
+++ b/static/src/js/components/LibraryWork.vue
@@ -7,6 +7,9 @@
     <div class="urn">
       {{ work.urn }}
     </div>
+    <div class="text-group">
+      {{ work.textGroup.label }}
+    </div>
     <div class="versions">
       <template v-for="text in work.texts">
         <a :key="text.urn" :href="text.reader_url" class="badge badge-light">

--- a/static/src/js/components/LibraryWork.vue
+++ b/static/src/js/components/LibraryWork.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="work" :key="work.urn">
+    <div class="filler">&nbsp;</div>
+    <div class="label">
+      <a :href="work.url">{{ work.label }}</a>
+    </div>
+    <div class="urn">
+      {{ work.urn }}
+    </div>
+    <div class="versions">
+      <template v-for="text in work.texts">
+        <a :key="text.urn" :href="text.reader_url" class="badge badge-light">
+          {{ text.lang }}
+        </a>{{ ' ' }}
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['work', 'filtered'],
+};
+</script>
+

--- a/static/src/js/components/LibraryWork.vue
+++ b/static/src/js/components/LibraryWork.vue
@@ -1,14 +1,13 @@
 <template>
   <div class="work" :key="work.urn">
-    <div class="filler">&nbsp;</div>
     <div class="label">
       <a :href="work.url">{{ work.label }}</a>
     </div>
-    <div class="urn">
-      {{ work.urn }}
-    </div>
     <div class="text-group">
       {{ work.textGroup.label }}
+    </div>
+    <div class="urn">
+      {{ work.urn }}
     </div>
     <div class="versions">
       <template v-for="text in work.texts">
@@ -25,4 +24,3 @@ export default {
   props: ['work', 'filtered'],
 };
 </script>
-

--- a/static/src/js/store/library.js
+++ b/static/src/js/store/library.js
@@ -1,12 +1,61 @@
 import qs from 'query-string';
+import { URN } from '../scaife-viewer';
 
 module.exports = {
   state: {
     textGroups: [],
+    textGroupWorks: [],
+    textGroupTexts: [],
+    textGroupUrns: {},
     allTextGroups: null,
+    allTextGroupWorks: null,
+    allTextGroupTexts: null,
+    sortKind: 'cts-urn',
     works: [],
     allWorks: null,
     toc: [],
+  },
+  getters: {
+    hydratedTextGroups(state) {
+      return state.textGroups.map(textGroup => ({
+        ...textGroup,
+        urn: textGroup.urn.toString(),
+        works: textGroup.works.map(work => ({
+          ...state.textGroupUrns[work.urn.toString()],
+          urn: work.urn.toString(),
+          texts: work.texts.map(text => ({
+            ...state.textGroupUrns[text.urn.toString()],
+            urn: text.urn.toString(),
+          })),
+        })),
+      }));
+    },
+    sortedByURN(state, getters) {
+      const tmp = [...getters.hydratedTextGroups];
+      tmp.sort((a, b) => a.urn.localeCompare(b.urn));
+      return tmp;
+    },
+    sortedByTextGroup(state, getters) {
+      const tmp = [...getters.hydratedTextGroups];
+      tmp.sort((a, b) => a.label.localeCompare(b.label));
+      return tmp;
+    },
+    hydratedWorks(state) {
+      return state.textGroupWorks.map(work => ({
+        ...state.textGroupUrns[work.urn.toString()],
+        urn: work.urn.toString(),
+        textGroup: state.textGroupUrns[work.urn.upTo('textGroup')],
+        texts: work.texts.map(text => ({
+          ...state.textGroupUrns[text.urn.toString()],
+          urn: text.urn.toString(),
+        })),
+      }));
+    },
+    sortedByWork(state, getters) {
+      const tmp = [...getters.hydratedWorks];
+      tmp.sort((a, b) => a.label.localeCompare(b.label));
+      return tmp;
+    },
   },
   actions: {
     async loadTextGroupList({ commit }) {
@@ -14,7 +63,50 @@ module.exports = {
       const opts = { headers: { Accept: 'application/json' } };
       const res = await fetch(url, opts);
       const textInventory = await res.json();
-      commit('setTextGroups', textInventory.text_groups);
+      const textGroups = [];
+      const works = [];
+      const texts = [];
+      const textGroupUrns = {};
+
+      textInventory.text_groups.forEach((textGroup) => {
+        const tg = {
+          ...textGroup,
+          urn: new URN(textGroup.urn),
+          works: textGroup.works.map(work => ({
+            ...work,
+            urn: new URN(work.urn),
+            texts: work.texts.map(text => ({
+              ...text,
+              urn: new URN(text.urn),
+            })),
+          })),
+        };
+        textGroups.push(tg);
+        textGroupUrns[textGroup.urn] = tg;
+      });
+      textInventory.works.forEach((work) => {
+        const w = {
+          ...work,
+          urn: new URN(work.urn),
+          texts: work.texts.map(text => ({
+            ...text,
+            urn: new URN(text.urn),
+          })),
+        };
+        works.push(w);
+        textGroupUrns[work.urn] = w;
+      });
+      textInventory.texts.forEach((text) => {
+        const t = {
+          urn: new URN(text.urn),
+          ...text,
+        };
+        texts.push(t);
+        textGroupUrns[text.urn] = t;
+      });
+
+      commit('setTextGroups', { textGroups, works, texts });
+      commit('setTextGroupUrns', { textGroupUrns });
     },
     filterTextGroups({ state, commit }, query) {
       if (state.allTextGroups) {
@@ -23,22 +115,39 @@ module.exports = {
           if (textGroup.label.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
             textGroups.push(textGroup);
           } else {
-            const works = [];
-            textGroup.works.forEach((work) => {
-              if (work.label.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
-                works.push(work);
-              }
+            const works = textGroup.works.filter((work) => {
+              const { label } = state.textGroupUrns[work.urn.toString()];
+              return label.toLowerCase().indexOf(query.toLowerCase()) !== -1;
             });
             if (works.length > 0) {
               textGroups.push({ ...textGroup, works });
             }
           }
         });
-        commit('setTextGroups', textGroups);
+        commit('setTextGroups', { textGroups });
       }
     },
     resetTextGroups({ state, commit }) {
-      commit('setTextGroups', [...state.allTextGroups]);
+      commit('setTextGroups', { textGroups: [...state.allTextGroups] });
+    },
+    filterTextGroupWorks({ state, commit }, query) {
+      if (state.allTextGroupWorks) {
+        const works = [];
+        state.allTextGroupWorks.forEach((work) => {
+          if (work.label.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+            works.push(work);
+          } else {
+            const { label } = state.textGroupUrns[work.urn.upTo('textGroup')];
+            if (label.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+              works.push(work);
+            }
+          }
+        });
+        commit('setTextGroups', { works });
+      }
+    },
+    resetTextGroupWorks({ state, commit }) {
+      commit('setTextGroups', { works: [...state.allTextGroupWorks] });
     },
     async loadWorkList({ commit }, textGroupUrl) {
       let params;
@@ -109,11 +218,31 @@ module.exports = {
     },
   },
   mutations: {
-    setTextGroups(state, textGroups) {
-      if (!state.allTextGroups) {
-        state.allTextGroups = [...textGroups];
+    setTextGroups(state, { textGroups, works, texts }) {
+      if (textGroups !== undefined) {
+        if (!state.allTextGroups) {
+          state.allTextGroups = [...textGroups];
+        }
+        state.textGroups = textGroups;
       }
-      state.textGroups = textGroups;
+      if (works !== undefined) {
+        if (!state.allTextGroupWorks) {
+          state.allTextGroupWorks = [...works];
+        }
+        state.textGroupWorks = works;
+      }
+      if (texts !== undefined) {
+        if (!state.allTextGroupTexts) {
+          state.allTextGroupTexts = [...texts];
+        }
+        state.textGroupTexts = texts;
+      }
+    },
+    setTextGroupUrns(state, { textGroupUrns }) {
+      state.textGroupUrns = textGroupUrns;
+    },
+    setLibrarySort(state, { kind }) {
+      state.sortKind = kind;
     },
     setWorks(state, works) {
       if (!state.allWorks) {

--- a/static/src/scss/_library.scss
+++ b/static/src/scss/_library.scss
@@ -121,35 +121,41 @@ section.hero {
 .library-component {
   margin: 50px 0 100px;
 
-  .toggle-all {
-    font-size: 14px;
-    color: $gray-500;
-    span {
-      color: $gray-600;
-      cursor: pointer;
-      &:hover {
-        color: $black;
+  .controls {
+    display: flex;
+    justify-content: space-between;
+
+    .toggle-all {
+      font-size: 14px;
+      color: $gray-500;
+      span {
+        color: $gray-600;
+        cursor: pointer;
+        &:hover {
+          color: $black;
+        }
       }
     }
-  }
-  .sort {
-    font-size: 14px;
-    color: $gray-500;
-    span {
-      color: $gray-600;
-      cursor: pointer;
-      &:hover {
-        color: $black;
-      }
-      &.active {
-        font-weight: bold;
+    .sort {
+      font-size: 14px;
+      color: $gray-500;
+      span {
+        cursor: pointer;
+        color: $gray-600;
+        &.active {
+          color: $black;
+          &:hover {
+            color: $black;
+          }
+        }
+        &:hover {
+          color: $gray-700;
+        }
       }
     }
   }
   .text-groups {
-    &.filtered {
-      margin-top: 47px;
-    }
+    margin-top: 15px;
     .text-group {
       font-family: 'Noto Serif';
       &.open {
@@ -223,6 +229,54 @@ section.hero {
                 color: $white;
               }
             }
+          }
+        }
+      }
+    }
+  }
+  .flat-work-list {
+    margin-top: 15px;
+    .work {
+      margin-top: 8px;
+      font-family: 'Noto Serif';
+      &:hover {
+        background: $gray-200;
+        .versions {
+          display: block;
+        }
+      }
+      display: flex;
+      flex-wrap: wrap;
+      .label {
+        padding-left: 25px;
+        width: 300px;
+        line-height: 24px;
+      }
+      .text-group {
+        padding-left: 25px;
+        width: 400px;
+        line-height: 24px;
+      }
+      .urn {
+        padding-left: 25px;
+        width: 300px;
+        font-family: monospace;
+        font-size: 14px;
+        line-height: 26px;
+        color: $gray-600;
+      }
+      .versions {
+        padding-left: 25px;
+        display: none;
+        line-height: 26px;
+        font-family: 'Noto Sans';
+        .badge {
+          font-weight: normal;
+          margin-top: 4px;
+          vertical-align: top;
+          &:hover {
+            background: $perseus-red;
+            color: $white;
           }
         }
       }

--- a/static/src/scss/_library.scss
+++ b/static/src/scss/_library.scss
@@ -132,6 +132,20 @@ section.hero {
       }
     }
   }
+  .sort {
+    font-size: 14px;
+    color: $gray-500;
+    span {
+      color: $gray-600;
+      cursor: pointer;
+      &:hover {
+        color: $black;
+      }
+      &.active {
+        font-weight: bold;
+      }
+    }
+  }
   .text-groups {
     &.filtered {
       margin-top: 47px;


### PR DESCRIPTION
Top-level library page now allows sorting by CTS URN, Text Group or Work.

If sorting by work, the list become flat (no grouping by text group) but the text group is shown in an extra column (and is still part of the filtering)

Fixes issue #196 
