### PR TITLE
version selector improvements

### DIFF
--- a/static/src/js/reader/version-selector.vue
+++ b/static/src/js/reader/version-selector.vue
@@ -8,8 +8,13 @@
     </div>
     <div :class="['version-option', 'dropdown-menu', { show }]">
       <router-link v-for="version in versions" :key="version.urn" class="dropdown-item" :to="to(version.urn)" @click.native="handleItemClick">
-        <span v-if="version.urn === leftText.urn" class="side">L</span>
-        <span v-if="version.urn === rightText.urn" class="side">R</span>
+        <template v-if="rightPassage">
+          <span v-if="version.urn === leftText.urn" class="side">L</span>
+          <span v-if="version.urn === rightText.urn" class="side">R</span>
+        </template>
+        <template v-else>
+          <span v-if="version.urn === leftText.urn" class="side">&nbsp;</span>
+        </template>
         <div>
           <div class="label">
             {{ version.label }}
@@ -40,6 +45,9 @@ export default {
     },
     rightText() {
       return this.$store.state.reader.rightText;
+    },
+    rightPassage() {
+      return this.$store.state.reader.rightPassage;
     },
   },
   methods: {

--- a/static/src/js/reader/version-selector.vue
+++ b/static/src/js/reader/version-selector.vue
@@ -8,12 +8,19 @@
     </div>
     <div :class="['version-option', 'dropdown-menu', { show }]">
       <router-link v-for="version in versions" :key="version.urn" class="dropdown-item" :to="to(version.urn)" @click.native="handleItemClick">
-        {{ version.label }}
-        <div class="metadata">{{ version.human_lang }} {{ version.kind }}</div>
+        <span v-if="version.urn === leftText.urn" class="side">L</span>
+        <span v-if="version.urn === rightText.urn" class="side">R</span>
+        <div>
+          <div class="label">
+            {{ version.label }}
+          </div>
+          <div class="description">{{ version.description }}</div>
+          <div class="metadata">{{ version.human_lang }} {{ version.kind }}</div>
+        </div>
       </router-link>
       <template v-if="remove">
         <div class="dropdown-divider"></div>
-        <router-link class="dropdown-item remove" :to="remove()" @click.native="handleRemoveClick">remove</router-link>
+        <router-link class="dropdown-item remove" :to="remove()" @click.native="handleRemoveClick">remove column</router-link>
       </template>
     </div>
   </div>
@@ -26,6 +33,14 @@ export default {
     return {
       show: false,
     };
+  },
+  computed: {
+    leftText() {
+      return this.$store.state.reader.leftText;
+    },
+    rightText() {
+      return this.$store.state.reader.rightText;
+    },
   },
   methods: {
     toggleMenu() {

--- a/static/src/scss/_reader.scss
+++ b/static/src/scss/_reader.scss
@@ -82,6 +82,7 @@ body.reader {
 
   .btn-group.btn-group-left {
     margin-bottom: 10px;
+    width: 100%;
   }
   .btn-group.btn-group-left .dropdown-toggle {
     padding: 0.2rem 0.5rem 0.2rem 0.3rem !important;
@@ -97,6 +98,7 @@ body.reader {
   }
 
   .version-select {
+    // width: 100%;
     padding: 0.5rem 0.75rem 0.5rem 0;
     text-align: left;
     white-space: normal;
@@ -108,11 +110,14 @@ body.reader {
       font-family: 'Noto Sans';
       color: $gray-500;
       font-style: italic;
+      margin-top: 4px;
       font-size: 12px;
       line-height: 12px;
     }
   }
   .version-option {
+    width: 100%;
+    max-width: 500px;
     a {
       white-space: normal;
       padding: 0.25rem 1rem;
@@ -121,22 +126,43 @@ body.reader {
           color: $perseus-red-lighter;
         }
       }
+      &:hover {
+      }
       &.remove {
+        padding: 0 1rem;
+        font-size: 14px;
         color: $red;
         &:active {
           color: $white;
         }
       }
+      display: flex;
+      .side {
+        @extend .badge;
+        font-family: 'Noto Sans';
+        color: $gray-600;
+        background: $gray-200;
+        margin-right: 0.5em;
+      }
     }
-    font-size: 14px;
-    line-height: 16px;
-    font-family: 'Noto Serif';
-    .metadata {
+    .label {
+      font-family: 'Noto Serif';
+      font-weight: bold;
+      font-size: 14px;
+      line-height: 16px;
+    }
+    .description {
       font-family: 'Noto Sans';
       color: $gray-600;
+      font-size: 12px;
+      line-height: 14px;
+    }
+    .metadata {
+      font-family: 'Noto Serif';
+      color: $gray-800;
       font-style: italic;
       font-size: 12px;
-      line-height: 12px;
+      line-height: 14px;
     }
   }
   .text-loading:not(.partial-loader) {


### PR DESCRIPTION
- show version description in dropdown
- indicate in the dropdown which version is on the left and which is on the right
- make dropdown wider for better readability (especially in light of showing description)
- improve overall styling of selector


fixes #233 