### PR TITLE
Add docker-compose.yml for running scaife-viewer server + PostgreSQL

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@
 
 - Patrick Altman
 - Jake Wegner
+- Ryan Baumann

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2.2"
+services:
+  scaife-viewer:
+    build: .
+    ports:
+      - "8000:8000"
+    links:
+      - "postgres"
+    depends_on:
+      - "postgres"
+    command:
+      - "./docker-run-server.sh"
+    environment:
+      - DATABASE_URL=postgres://root:scaife@postgres/scaife-viewer
+  postgres:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_PASSWORD=scaife
+      - POSTGRES_USER=root
+      - POSTGRES_DB=scaife-viewer

--- a/docker-run-server.sh
+++ b/docker-run-server.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+python manage.py migrate
+python manage.py loaddata sites
+honcho start web

--- a/docker-run-server.sh
+++ b/docker-run-server.sh
@@ -2,4 +2,4 @@
 
 python manage.py migrate
 python manage.py loaddata sites
-honcho start web
+exec honcho start web


### PR DESCRIPTION
This adds a `docker-compose.yml` for running the scaife-viewer server + PostgreSQL inside `docker-compose`, with e.g. `docker-compose up`

There are some other related changes that were made to make this work, but I tried to make them as unobtrusive as possible.

* The main `Dockerfile` now copies all of `bin`/`lib` in from the `static` node stage in order to get `node` and `npm`. There may be a better way to do this.
* The database URL used by django can now optionally be set by the environment variable `DJ_DATABASE_URL`
* `webpack-dev-server` now binds to host `0.0.0.0`, which seemed to be the easiest way for me to get Docker host/port mapping to work. This still winds up restricted to access by `localhost`, which you can (apparently) expand by setting `ALLOWED_HOSTS`.