### PR TITLE
Hook up Latin morpheus

### DIFF
--- a/static/src/js/reader/widgets/morpheus.vue
+++ b/static/src/js/reader/widgets/morpheus.vue
@@ -66,13 +66,18 @@ export default {
       }
       return selectedWords[0];
     },
+    text() {
+      const text = this.$store.getters['reader/text'];
+      return text;
+    },
   },
   methods: {
     fetchData() {
       const word = this.selectedWord;
+      const lang = this.text.metadata.lang;
       if (word) {
         this.loading = true;
-        const url = `/morpheus/?word=${word.w}`;
+        const url = `/morpheus/?word=${word.w}&lang=${lang}`;
         const headers = new Headers({
           Accept: 'application/json',
         });


### PR DESCRIPTION
Fixes: #244

This now requires a `lang` param with a value of `grc` or `lat` passed in from the morpheus JS widget.

I've also used an HTTP 400 (instead of 404) for invalid requests, as I thought that might be more correct.