### PR TITLE
Add ExtractTextPlugin to Webpack dev config

### DIFF
--- a/static/webpack.dev.js
+++ b/static/webpack.dev.js
@@ -2,6 +2,7 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 const webpack = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const utils = require('./utils');
 
 const optionalPlugins = [];
@@ -12,10 +13,11 @@ if (process.env.BUNDLE_ANALYZER === 'on') {
     analyzerPort: 3001,
   }));
 }
+const extractCss = new ExtractTextPlugin('css/app.css');
 
 module.exports = merge(common, {
   module: {
-    rules: utils.styleLoaders({ sourceMap: true }),
+    rules: utils.styleLoaders({ sourceMap: true, extracter: extractCss }),
   },
   devtool: 'cheap-module-eval-source-map',
   devServer: {
@@ -35,6 +37,7 @@ module.exports = merge(common, {
   plugins: [
     new webpack.NamedModulesPlugin(),
     new webpack.HotModuleReplacementPlugin(),
+    extractCss,
     ...optionalPlugins,
   ],
 });


### PR DESCRIPTION
Copy the `ExtractTextPlugin` configuration in `webpack.prod.js` to `webpack.dev.js`. Without `ExtractTextPlugin` in the dev config, I wasn't able to get CSS to load when running the application locally (but the Bootstrap CSS still worked).

---

Before:

![before](https://user-images.githubusercontent.com/3039310/42395403-cede8176-812b-11e8-9624-0a39dfa5eaf9.png)

After:

![after](https://user-images.githubusercontent.com/3039310/42395406-d22e3bc8-812b-11e8-83be-b2fa604e242d.png)
