### PR TITLE
Use border to prevent text shifting

### DIFF
--- a/static/src/scss/_text.scss
+++ b/static/src/scss/_text.scss
@@ -123,11 +123,13 @@ div.text {
     cursor: pointer;
   }
   span.w.selected, span.w.highlighted {
-    padding: 0 0.1em 0.1em 0.15em;
+    border-style: solid;
+    border-width: 0 0.1em 0.1em 0.15em;
     margin: 0 -0.1em -0.1em -0.15em;
   }
   span.w.selected {
     background-color: $selected-color;
+    border-color: $selected-color;
   }
   span.w.highlighted {
     background-color: $highlight-color;


### PR DESCRIPTION
Minor CSS change to use a border instead of padding in order to prevent text shifting around. Before this change, a selected word took up slightly more space than an unselected word. This caused to the right of a word to shift every time a word was selected. The pixel difference is small, but it's pretty noticeable as a user when selecting different words.

---

Screenshot of viewer with no word selected:

<img width="596" alt="nothing" src="https://user-images.githubusercontent.com/3039310/42395215-1475432e-812b-11e8-802c-fd60202a47b6.png">

Screenshot with word selected before this PR:

<img width="596" alt="selected-before" src="https://user-images.githubusercontent.com/3039310/42395224-1f2582ca-812b-11e8-9bf0-286b4a9058c4.png">

Screenshot with word selected after this PR:

<img width="596" alt="selected-after" src="https://user-images.githubusercontent.com/3039310/42395233-26281f6a-812b-11e8-948a-b13595e9c523.png">
