### PR TITLE
Add support for hosting at a path other than root

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,31 @@ To prepare messages:
 If you need to add a language; add it to `LANGUAGES` in settings.py and run:
 
     python manage.py makemessages --locale <lang>
+
+
+## Hosting Off-Root
+
+If you need to host at a place other than root, for example, if you need to have
+a proxy serve at some path off your domain like http://yourdomain.com/perseus/,
+you'll need to do the following:
+
+1. Set the environment variable, `FORCE_SCRIPT_NAME` to point to your script:
+
+```
+    export FORCE_SCRIPT_NAME=/perseus  # this front slash is important
+```
+
+2. Make sure this is set prior to runing `npm run build` as well as prior to and
+   part of your wsgi startup environment.
+
+3. Then, you just set your proxy to point to the location of where your wsgi
+   server is running.  For example, if you are running wsgi on port 8000 you can
+   have this snippet inside your nginx config for the server:
+
+```
+    location /perseus/ {
+        proxy_pass        http://localhost:8000/;
+    }
+```
+
+That should be all you need to do.

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -295,8 +295,8 @@ if "SENTRY_DSN" in os.environ:
     }
 
 
-if "FORCE_SCRIPT_NAME" in os.environ:
-    FORCE_SCRIPT_NAME = os.environ["FORCE_SCRIPT_NAME"]
+FORCE_SCRIPT_NAME = os.environ.get("FORCE_SCRIPT_NAME")
+if FORCE_SCRIPT_NAME:
     STATIC_URL = f"{FORCE_SCRIPT_NAME}{STATIC_URL}"
     WHITENOISE_STATIC_PREFIX = "static/"
 

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -294,4 +294,11 @@ if "SENTRY_DSN" in os.environ:
         "dsn": os.environ["SENTRY_DSN"],
     }
 
+
+if "FORCE_SCRIPT_NAME" in os.environ:
+	    FORCE_SCRIPT_NAME = os.environ["FORCE_SCRIPT_NAME"]
+	    STATIC_URL = f"{FORCE_SCRIPT_NAME}{STATIC_URL}"
+	    WHITENOISE_STATIC_PREFIX = "static/"
+
+
 ELASTICSEARCH_HOSTS = os.environ.get("ELASTICSEARCH_HOSTS", "localhost").split(",")

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -296,9 +296,9 @@ if "SENTRY_DSN" in os.environ:
 
 
 if "FORCE_SCRIPT_NAME" in os.environ:
-	    FORCE_SCRIPT_NAME = os.environ["FORCE_SCRIPT_NAME"]
-	    STATIC_URL = f"{FORCE_SCRIPT_NAME}{STATIC_URL}"
-	    WHITENOISE_STATIC_PREFIX = "static/"
+    FORCE_SCRIPT_NAME = os.environ["FORCE_SCRIPT_NAME"]
+    STATIC_URL = f"{FORCE_SCRIPT_NAME}{STATIC_URL}"
+    WHITENOISE_STATIC_PREFIX = "static/"
 
 
 ELASTICSEARCH_HOSTS = os.environ.get("ELASTICSEARCH_HOSTS", "localhost").split(",")

--- a/scaife_viewer/templates/homepage.html
+++ b/scaife_viewer/templates/homepage.html
@@ -18,7 +18,7 @@
     <h1>Scaife Viewer</h1>
 
     <p class="buttons">
-      <a class="btn btn-primary" href="/library/">Browse Library</a>
+      <a class="btn btn-primary" href="{% url 'library' %}">Browse Library</a>
       <a class="btn btn-secondary" href="{% url 'search' %}">Text Search</a>
     </p>
 

--- a/scaife_viewer/templates/library/cts_text.html
+++ b/scaife_viewer/templates/library/cts_text.html
@@ -8,7 +8,7 @@
 
 {% block hero %}
   <h2>
-    <a href="/library/">Library &gt;</a>
+    <a href="{% url 'library' %}">Library &gt;</a>
     {% for breadcrumb in text.ancestors %}
       <a href="{% url 'library_collection' breadcrumb.urn %}">{{ breadcrumb.label }}{% if not forloop.last %} &gt;{% endif %}</a>
     {% endfor %}

--- a/scaife_viewer/templates/library/cts_textgroup.html
+++ b/scaife_viewer/templates/library/cts_textgroup.html
@@ -8,7 +8,7 @@
 
 {% block hero %}
   <h2>
-    <a href="/library/">Library</a>
+    <a href="{% url 'library' %}">Library</a>
     {% for breadcrumb in textgroup.ancestors %}
       <a href="{% url 'api:library_collection' breadcrumb.urn %}">{{ breadcrumb.label }}{% if not forloop.last %} &gt;{% endif %}</a>
     {% endfor %}

--- a/scaife_viewer/templates/library/cts_work.html
+++ b/scaife_viewer/templates/library/cts_work.html
@@ -8,7 +8,7 @@
 
 {% block hero %}
   <h2>
-    <a href="/library/">Library &gt;</a>
+    <a href="{% url 'library' %}">Library &gt;</a>
     {% for breadcrumb in work.ancestors %}
       <a href="{% url 'library_collection' breadcrumb.urn %}">{{ breadcrumb.label }}{% if not forloop.last %} &gt;{% endif %}</a>
     {% endfor %}

--- a/scaife_viewer/templates/site_base.html
+++ b/scaife_viewer/templates/site_base.html
@@ -38,7 +38,7 @@
             {% block nav %}
               <ul class="navbar-nav mr-auto">
                 {% block nav_items %}
-                  <li class="nav-item"><a class="nav-link" href="/library/">Browse Library</a></li>
+                  <li class="nav-item"><a class="nav-link" href="{% url 'library' %}">Browse Library</a></li>
                   <li class="nav-item"><a class="nav-link" href="{% url 'search' %}">Text Search</a></li>
                 {% endblock %}
               </ul>

--- a/static/src/js/api/http.js
+++ b/static/src/js/api/http.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const baseURL = process.env.FORCE_SCRIPT_NAME || '';
+const baseURL = process.env.FORCE_SCRIPT_NAME || '/';
 
 const HTTP = axios.create({
   baseURL,

--- a/static/src/js/api/http.js
+++ b/static/src/js/api/http.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const baseURL = process.env.FORCE_SCRIPT_NAME || '';
+
 const HTTP = axios.create({
-  baseURL: '/',
+  baseURL,
   xsrfHeaderName: 'X-CSRFToken',
   xsrfCookieName: 'csrftoken',
 });

--- a/static/src/js/router/index.js
+++ b/static/src/js/router/index.js
@@ -5,9 +5,23 @@ import routes from './routes';
 
 Vue.use(Router);
 
+let base = process.env.FORCE_SCRIPT_NAME || '';
+
+// From vue-router docs:
+// The base URL of the app. For example, if the entire single page application
+// is served under /app/, then base should use the value "/app/".
+if (base) {
+  if (!base.startsWith('/')) {
+    base = `/${base}`;
+  }
+  if (!base.endsWith('/')) {
+    base = `${base}/`;
+  }
+}
+
 const router = new Router({
   mode: 'history',
-  base: '',
+  base,
   routes,
 });
 

--- a/static/src/js/router/index.js
+++ b/static/src/js/router/index.js
@@ -5,7 +5,7 @@ import routes from './routes';
 
 Vue.use(Router);
 
-let base = process.env.FORCE_SCRIPT_NAME || '';
+let base = process.env.FORCE_SCRIPT_NAME || '/';
 
 // From vue-router docs:
 // The base URL of the app. For example, if the entire single page application

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,16 +60,14 @@ const plugins = [
   new CopyWebpackPlugin([
     { from: './static/src/images/**/*', to: path.resolve('./static/dist/images/[name].[ext]'), toType: 'template' },
   ]),
+  new webpack.EnvironmentPlugin([
+    'NODE_ENV',
+    'FORCE_SCRIPT_NAME',
+  ]),
 ];
 
 if (devMode) {
   styleRule.use = ['css-hot-loader', ...styleRule.use];
-} else {
-  plugins.push(
-    new webpack.EnvironmentPlugin([
-      'NODE_ENV',
-    ]),
-  );
 }
 
 module.exports = {


### PR DESCRIPTION
To test this:

1. `brew install nginx`
2. Replace default nginx conf (`/usr/local/etc/nginx/nginx.conf`) with contents of [this gist](https://gist.github.com/jacobwegner/3ee90e8d53e1ba47db7a606a1bd03c0c)
3. set the `FORCE_SCRIPT_NAME` environment variable in both terminals (the one for `npm start` and the one for `manage.py run server`) - `export FORCE_SCRIPT_NAME=/perseus`
4. run `npm start` and `manage.py runserver` in the two terminals
5. open up http://localhost:8001/perseus/

You should see the root of the app.  Clicking around should load content from the API appropriately.  There are a few cases where urls are hardcoded that I still need to track down and fix (e.g. `/library/` in the main header nav).

---

Big thanks to @jacobwegner on this!