### PR TITLE
Switch to StaticFileStorage backend

### DIFF
--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -81,7 +81,7 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 if "SECRET_KEY" in os.environ:
     SECRET_KEY = os.environ["SECRET_KEY"]


### PR DESCRIPTION
There is a conflict between the hashing of files in `ManifestStaticFilesStorage` and how the `render_bundle` template tag provided by [django-webpack-loader/](https://github.com/owais/django-webpack-loader/) resolves static assets being served from the project.

Since Webpack's chunking is already generating hashed filenames, we can remove `ManifestStaticFilesStorage` and fall back to the default static file storage backend.