### PR TITLE
Fix more regressions found on dev

### DIFF
--- a/scaife_viewer/cts/tei.xsl
+++ b/scaife_viewer/cts/tei.xsl
@@ -228,18 +228,12 @@
   </xsl:template>
 
   <xsl:template match="t:quote">
+    <xsl:element name="blockquote">
       <xsl:apply-templates/>
+    </xsl:element>
   </xsl:template>
 
-  <xsl:template match="t:figure">
-<div>Figure here!
-<!--<figure>
-<xsl:element name="img">
-      <xsl:attribute name="src"><xsl:value-of select="./graphic/@url"/></xsl:attribute>
-      <figcaption><em><xsl:value-of select="./head"/></em></figcaption>
-    </xsl:element>
-</figure>--></div>
-</xsl:template>
+  <xsl:template match="t:figure" />
 
   <xsl:template match="t:lg">
     <div class="lg"><xsl:apply-templates/></div>
@@ -261,17 +255,10 @@
     <div class="milestone"><xsl:value-of select="@n"/></div>
   </xsl:template>
 
-  <xsl:template match="t:ab">
+  <xsl:template match="t:p">
     <p>
       <xsl:apply-templates/>
     </p>
-  </xsl:template>
-
-  <xsl:template match="t:foreign[1]">
-    <xsl:choose>
-      <xsl:when test="preceding-sibling::t:ref[1][@cRef]"><strong><xsl:value-of select="."/></strong></xsl:when>
-      <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
-    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="text()">
@@ -318,6 +305,7 @@
   </xsl:template>
 
   <xsl:template match="t:lb">
+    <br/>
   </xsl:template>
 
   <xsl:template match="t:ex">
@@ -333,20 +321,14 @@
   </xsl:template>
 
   <xsl:template match="t:bibl">
-    <xsl:choose>
-      <xsl:when test="t:author"></xsl:when>
-      <xsl:when test="t:title"></xsl:when>
-      <xsl:otherwise>
-        <xsl:element name="cite">
-          <xsl:if test="@n">
-            <xsl:attribute name="data-ref">
-              <xsl:value-of select="@n" />
-            </xsl:attribute>
-          </xsl:if>
-          <xsl:value-of select="." />
-        </xsl:element>
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:element name="cite">
+      <xsl:if test="@n">
+        <xsl:attribute name="data-ref">
+          <xsl:value-of select="@n" />
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:value-of select="." />
+    </xsl:element>
   </xsl:template>
 
   <xsl:template match="t:gap">
@@ -418,17 +400,6 @@
     </a>
   </xsl:template>
 
-  <xsl:template match="t:ab/t:ref[@cRef]">
-    <span class="cRef">◉</span><xsl:text> </xsl:text><xsl:apply-templates/>
-  </xsl:template>
-
-  <xsl:template match="t:ab/t:ref[@target]">
-    <xsl:element name="ref-lower">
-      <xsl:attribute name="urn"><xsl:value-of select="@target"/></xsl:attribute>
-      <xsl:apply-templates/>
-    </xsl:element>
-  </xsl:template>
-
   <xsl:template match="t:choice">
     <span class="choice">
       <xsl:attribute name="title">
@@ -437,42 +408,6 @@
       <xsl:value-of select="orig" /><xsl:text> </xsl:text>
     </span>
   </xsl:template>
-
-  <xsl:template match="t:hi">
-    <xsl:choose>
-        <xsl:when test="@rend='#bold'or @rend='bold'">
-          <strong><xsl:value-of select="."/></strong>
-        </xsl:when>
-          <xsl:when test="@rend='italic'">
-          <em><xsl:value-of select="."/></em>
-        </xsl:when>
-        <xsl:when test="@rend='underline'">
-          <u><xsl:value-of select="."/></u>
-        </xsl:when>
-      <xsl:when test="@rend='subscript'">
-          <sub><xsl:value-of select="."/></sub>
-        </xsl:when>
-    <xsl:when test="@rend='superscript'">
-          <sup><xsl:value-of select="."/></sup>
-        </xsl:when>
-    <xsl:when test="@rend='smallcaps'">
-          <small><xsl:value-of select="."/></small>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="."/>
-        </xsl:otherwise>
-      </xsl:choose>
-  </xsl:template>
-
-<!--<xsl:template match="t:ab>
-    <xsl:element name="text-part">
-      <xsl:attribute name="class">ab<xsl:attribute>
-     <xsl:apply-templates/>
-    </xsl:element>
-  </xsl:template> -->
-
-
-
 
   <xsl:template match="t:unclear">
     <span class="unclear"><xsl:value-of select="." /></span>
@@ -492,7 +427,6 @@
         <xsl:text>translation lang_</xsl:text>
         <xsl:value-of select="@xml:lang"/>
       </xsl:attribute>
-
 
       <xsl:apply-templates/>
 

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -272,7 +272,7 @@ CACHES = {
 
 resolver = os.environ.get("CTS_RESOLVER", "api")
 if resolver == "api":
-    CTS_API_ENDPOINT = os.environ.get("CTS_API_ENDPOINT", "http://localhost:8000/api/cts")
+    CTS_API_ENDPOINT = os.environ.get("CTS_API_ENDPOINT", "https://scaife-cts-dev.perseus.org/api/cts")
     CTS_RESOLVER = {
         "type": "api",
         "kwargs": {

--- a/scaife_viewer/templates/homepage.html
+++ b/scaife_viewer/templates/homepage.html
@@ -61,21 +61,11 @@
         <div class="col-md-6">
           <h2>Recent Changes</h2>
 
-          <h3>week of March 12th</h3>
+          <h3>week of March 18th, 2019</h3>
 
           <ul>
-            <li>added push and overlay style sidebars based on device width</li>
-            <li>added support for Latin in the Morpheus widget</li>
-            <li>improved stability and fixed various bugs</li>
-            <li>LAUNCH!</li>
-          </ul>
-
-          <h3>week of March 5th</h3>
-
-          <ul>
-            <li>changed passage notes and place annotations to appear in popovers</li>
-            <li>implemented passage healing for references which do not resolve</li>
-            <li>used a fallback API for word list widget when GVT does not contain the edition or work</li>
+            <li>launched a newsletter for <a href="https://scaife-viewer.org">The Scaife Viewer Project</a></li>
+            <li>improved stability and fixed various bugs; please <a href="https://github.com/scaife-viewer/scaife-viewer/issues">let us know</a> if you see anything out of the ordinary</li>
           </ul>
         </div>
       </div>

--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -116,7 +116,7 @@ class LibraryCollectionView(LibraryConditionMixin, BaseLibraryView):
 class LibraryCollectionVectorView(LibraryConditionMixin, View):
 
     def get(self, request, urn):
-        entries = request.GET.getlist("e")
+        entries = request.GET.getlist("e[]")
         try:
             cts.collection(urn)
         except cts.CollectionDoesNotExist:

--- a/static/src/js/api/index.js
+++ b/static/src/js/api/index.js
@@ -1,11 +1,9 @@
-import qs from 'query-string';
-
 import HTTP from './http';
 import pagination from './pagination';
 
 export default {
   getTextGroupList: cb => HTTP.get('library/json/').then(r => cb(r.data)),
-  getLibraryVector: (urn, params, cb) => HTTP.get(`library/vector/${urn}/?${qs.stringify({ e: params })}`).then(r => cb(r.data)),
+  getLibraryVector: (urn, params, cb) => HTTP.get(`library/vector/${urn}/`, { params }).then(r => cb(r.data)),
   getCollection: (urn, cb) => HTTP.get(`library/${urn}/json/`).then(r => cb(r.data)),
   getPassage: (urn, cb) => HTTP.get(`library/passage/${urn}/json/`)
     .then(r => cb({ ...r.data, ...pagination(r) })),

--- a/static/src/js/reader/Reader.vue
+++ b/static/src/js/reader/Reader.vue
@@ -35,7 +35,7 @@
             add parallel version
           </version-selector>
           <div id="overall" class="overall" :dir="text.metadata.rtl ? 'rtl' : 'ltr'">
-            <div class="upper">
+            <div :class="lowerPassageText ? 'upper' : 'upper-lower'">
               <div class="pg-left">
                 <router-link v-if="passage.metadata.prev" :to="toRef(passage.metadata.prev.ref)">
                   <span>

--- a/static/src/js/reader/Reader.vue
+++ b/static/src/js/reader/Reader.vue
@@ -59,7 +59,7 @@
                   </template>
                 </div>
                 <div class="right">
-                  <template v-if="rightText.metadata">
+                  <template v-if="rightText && rightText.metadata">
                     <version-selector :versions="versions" :to="toRightPassage" :remove="toRemoveRight">
                       {{ rightText.metadata.label }}
                       <div class="metadata">{{ rightText.metadata.human_lang }} {{ rightText.metadata.kind }}</div>

--- a/static/src/js/reader/widgets/WidgetMorpheus.vue
+++ b/static/src/js/reader/widgets/WidgetMorpheus.vue
@@ -43,6 +43,8 @@
 import constants from '../../constants';
 import TextLoader from '../TextLoader.vue';
 
+const baseURL = `${process.env.FORCE_SCRIPT_NAME}/` || '/';
+
 export default {
   name: 'widget-morpheus',
   watch: {
@@ -61,12 +63,17 @@ export default {
     enabled() {
       return this.text.metadata.lang === 'grc' || this.text.metadata.lang === 'lat';
     },
+    selectedWords2() {
+      return this.$store.getters['reader/selectedWords2'];
+    },
+    selectedWords() {
+      return this.$store.getters['reader/selectedWords'];
+    },
     selectedWord() {
-      const selectedWords = this.$store.getters['reader/selectedWords'];
-      if (selectedWords.length === 0) {
+      if (this.selectedWords2.length === 0) {
         return null;
       }
-      return selectedWords[0];
+      return this.selectedWords2[0];
     },
     text() {
       const text = this.$store.getters['reader/text'];
@@ -79,7 +86,7 @@ export default {
       const lang = this.text.metadata.lang;
       if (word) {
         this.loading = true;
-        const url = `/morpheus/?word=${word.w}&lang=${lang}`;
+        const url = `${baseURL}morpheus/?word=${word.w}&lang=${lang}`;
         const headers = new Headers({
           Accept: 'application/json',
         });

--- a/static/src/js/reader/widgets/WidgetMorpheus.vue
+++ b/static/src/js/reader/widgets/WidgetMorpheus.vue
@@ -43,7 +43,7 @@
 import constants from '../../constants';
 import TextLoader from '../TextLoader.vue';
 
-const baseURL = `${process.env.FORCE_SCRIPT_NAME}/` || '/';
+const baseURL = `${process.env.FORCE_SCRIPT_NAME}`;
 
 export default {
   name: 'widget-morpheus',
@@ -86,7 +86,7 @@ export default {
       const lang = this.text.metadata.lang;
       if (word) {
         this.loading = true;
-        const url = `${baseURL}morpheus/?word=${word.w}&lang=${lang}`;
+        const url = `${baseURL}/morpheus/?word=${word.w}&lang=${lang}`;
         const headers = new Headers({
           Accept: 'application/json',
         });

--- a/static/src/js/reader/widgets/WidgetSearch.vue
+++ b/static/src/js/reader/widgets/WidgetSearch.vue
@@ -236,6 +236,8 @@ export default {
     },
     updateHighlights() {
       // This should be in an action that is dispatched
+      // @@@ when moved to an action, we'll need to rewrite `SET_ANNOTATIONS`
+      // to use store.annotationsHash
       this.$store.commit(`reader/${constants.CLEAR_ANNOTATION}`, { key: 'highlighted' });
       this.activeResults.forEach(({ passage }) => {
         const params = {

--- a/static/src/js/reader/widgets/WidgetSearch.vue
+++ b/static/src/js/reader/widgets/WidgetSearch.vue
@@ -247,7 +247,7 @@ export default {
         };
         api.searchText(params, result => {
           const { highlights } = result.results[0];
-          this.$store.commit(constants.SET_ANNOTATIONS, {
+          this.$store.commit(`reader/${constants.SET_ANNOTATIONS}`, {
             tokens: highlights.map(({ w, i }) => `${w}[${i}]`),
             key: 'highlighted',
             value: true,

--- a/static/src/js/vuex/library/actions.js
+++ b/static/src/js/vuex/library/actions.js
@@ -1,5 +1,3 @@
-import qs from 'query-string';
-
 import api from '../../api';
 import constants from '../../constants';
 import transformTextGroupList from './transforms';
@@ -22,9 +20,9 @@ export default {
     // and texts.
 
     // vector for works
-    let params = qs.stringify({
+    let params = {
       e: textGroup.works.map(work => work.urn.replace(`${textGroup.urn}.`, '')),
-    });
+    };
     api.getLibraryVector(textGroup.urn, params, (worksVector) => {
       const workMap = worksVector.collections;
 
@@ -35,7 +33,7 @@ export default {
           e.push(textUrn.replace(`${textGroup.urn}.`, ''));
         });
       });
-      params = qs.stringify({ e });
+      params = { e };
 
       // vector for texts
       api.getLibraryVector(textGroup.urn, params, (textsVector) => {

--- a/static/src/js/vuex/reader/actions.js
+++ b/static/src/js/vuex/reader/actions.js
@@ -17,8 +17,10 @@ export default {
     if (state.versions === null) {
       ps.push(
         api.getCollection(leftUrn.upTo('work'), (work) => {
-          const texts = work.texts.map(text => new URN(text.urn).version);
-          api.getLibraryVector(work.urn, texts, (versions) => {
+          const params = {
+            e: work.texts.map(text => new URN(text.urn).version),
+          };
+          api.getLibraryVector(work.urn, params, (versions) => {
             commit(constants.SET_VERSIONS, { versions });
           });
         }),

--- a/static/src/js/vuex/reader/getters.js
+++ b/static/src/js/vuex/reader/getters.js
@@ -5,6 +5,16 @@ export default {
   passage(state) {
     return state.leftPassage;
   },
+  selectedWords2(state) {
+    const words = [];
+    Object.keys(state.annotationsHash).forEach((token) => {
+      if (state.annotationsHash[token].selected) {
+        const [, w, i] = /^([^[]+)(?:\[(\d+)\])?$/.exec(token);
+        words.push({ w, i });
+      }
+    });
+    return words;
+  },
   selectedWords(state) {
     const words = [];
     const { annotations } = state;

--- a/static/src/js/vuex/reader/mutations.js
+++ b/static/src/js/vuex/reader/mutations.js
@@ -157,6 +157,23 @@ export default {
     }
     ta[key] = value;
     annotations.set(token, ta);
+
+    if (singleton !== undefined && singleton && key === 'selected') {
+      // set all selected keys to false
+      const c = { ...state.annotationsHash };
+      Object.keys(state.annotationsHash).forEach((k) => {
+        c[k].selected = false;
+      });
+      state.annotationsHash = { ...c };
+    }
+    state.annotationsHash = {
+      ...state.annotationsHash,
+      [token]: {
+        ...state.annotationsHash[token],
+        [key]: value,
+      },
+    };
+
     state.annotationChange += 1;
   },
 

--- a/static/src/js/vuex/reader/state.js
+++ b/static/src/js/vuex/reader/state.js
@@ -15,6 +15,7 @@ export default {
   lowerPassageText: null,
   highlight: null,
   annotations: new Map(),
+  annotationsHash: {},
   annotationChange: 0,
   selectedLemmas: null,
   error: '',

--- a/static/src/scss/_reader.scss
+++ b/static/src/scss/_reader.scss
@@ -52,7 +52,6 @@ body.reader {
     .upper-lower {
       display: flex;
       justify-content: center;
-      overflow-y: auto;
     }
     .upper {
       max-height: 40vh;

--- a/static/src/scss/_reader.scss
+++ b/static/src/scss/_reader.scss
@@ -49,8 +49,13 @@ body.reader {
   }
 
   .overall {
+    .upper-lower {
+      display: flex;
+      justify-content: center;
+      overflow-y: auto;
+    }
     .upper {
-      max-height: 35vh;
+      max-height: 40vh;
       display: flex;
       justify-content: center;
       overflow-y: auto;
@@ -58,7 +63,7 @@ body.reader {
     .lower {
       border-top: 1px solid $gray-300;
       padding-top: 10px;
-      max-height: 50vh;
+      max-height: 40vh;
       display: flex;
       justify-content: center;
       overflow-y: auto;
@@ -124,6 +129,7 @@ body.reader {
     color: $gray-600;
     background: $white;
     border: none;
+    flex: 0 1 auto;
     &:hover {
       color: $black;
     }

--- a/static/src/scss/_text.scss
+++ b/static/src/scss/_text.scss
@@ -133,6 +133,7 @@ div.text {
   }
   span.w.highlighted {
     background-color: $highlight-color;
+    border-color: $highlight-color;
   }
   span.w.selected.highlighted {
     background-color: mix($highlight-color, $selected-color);

--- a/static/src/scss/_text.scss
+++ b/static/src/scss/_text.scss
@@ -145,6 +145,9 @@ div.text {
       }
       display: block;
       color: transparent;
+      div:first-of-type {
+        top: 0px;
+      }
       div {
         position: sticky;
         top: 20px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,10 +60,10 @@ const plugins = [
   new CopyWebpackPlugin([
     { from: './static/src/images/**/*', to: path.resolve('./static/dist/images/[name].[ext]'), toType: 'template' },
   ]),
-  new webpack.EnvironmentPlugin([
-    'NODE_ENV',
-    'FORCE_SCRIPT_NAME',
-  ]),
+  new webpack.EnvironmentPlugin({
+    NODE_ENV: 'development',
+    FORCE_SCRIPT_NAME: '',
+  }),
 ];
 
 if (devMode) {


### PR DESCRIPTION
- Revert `tei.xsl` changes
- Prefer https://scaife-cts-dev.perseus.org/api/cts as default `CTS_API_ENDPOINT`
- Fix morphology widget display
- Restore search highlights
- Fix reader style regressions
- Update recent changes