### PR TITLE
Fixes undefined error when pivot does not exist in search results

### DIFF
--- a/static/src/js/reader/widgets/WidgetSearch.vue
+++ b/static/src/js/reader/widgets/WidgetSearch.vue
@@ -136,7 +136,7 @@ export default {
             this.totalCount = 0;
             this.loading = false;
           } else {
-            if (res.results.length > 1 && res.pivot) {
+            if (res.pivot) {
               this.firstOffset = res.pivot.start_offset;
               this.lastOffset = res.pivot.end_offset;
             }

--- a/static/src/js/reader/widgets/WidgetSearch.vue
+++ b/static/src/js/reader/widgets/WidgetSearch.vue
@@ -136,7 +136,7 @@ export default {
             this.totalCount = 0;
             this.loading = false;
           } else {
-            if (res.results.length > 1) {
+            if (res.results.length > 1 && res.pivot) {
               this.firstOffset = res.pivot.start_offset;
               this.lastOffset = res.pivot.end_offset;
             }


### PR DESCRIPTION
Follow on to #331.

The underlying issue in #302 stems from the "pivot" functionality assuming a user navigates to the reader from the "Text Search" area of the app.

e.g. a user searches for "government":

https://scaife.perseus.org/search/?kind=form&q=government&tg=urn%3Acts%3Apdlpsci%3Abodin

and then clicks through to a given passage containing the result:

https://scaife.perseus.org/reader/urn:cts:pdlpsci:bodin.livrep.perseus-eng1:1.2/?q=government&qk=form

#331 _did_ fix the `undefined` error by ignoring the pivot when _exactly one_ search result was found when searching from a passage

https://scaife.perseus.org/reader/urn:cts:pdlpsci:bodin.livrep.perseus-eng1:1.1/?q=commo&qk=form

but did _not_ fix the case where more than one search result was found (when searching from a passage that didn't contain that term)

https://scaife.perseus.org/reader/urn:cts:pdlpsci:bodin.livrep.perseus-eng1:1.1?qk=form&q=Xenophon

We'll capture this scenario for future regression testing of search functionality.