### PR TITLE
Downgrade query-string dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7629,8 +7629,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -8794,12 +8793,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
-      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "strict-uri-encode": "^2.0.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -10212,9 +10212,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash.debounce": "^4.0.8",
     "parse-link-header": "^1.0.1",
     "popper.js": "^1.14.6",
-    "query-string": "^6.2.0",
+    "query-string": "^5.0",
     "vue": "^2.5.22",
     "vue-router": "^3.0.2",
     "vuex": "^3.1.0",


### PR DESCRIPTION
`query-string` v6 uses arrow functions; we'll downgrade in lieu of forcing webpack to transpile modules that depend on it in our build process.

- https://timonweb.com/tutorials/your-vuejs-react-code-throws-errors-in-ie11-and-you-dont-know-what-to-do/
- https://github.com/sindresorhus/query-string/pull/156