### PR TITLE
Add a widget to export passage as plain text or XML

### DIFF
--- a/scaife_viewer/cts/passage.py
+++ b/scaife_viewer/cts/passage.py
@@ -78,6 +78,13 @@ class Passage:
         text = self.textual_node().export(Mimetypes.PLAINTEXT)
         return unicodedata.normalize("NFC", text)
 
+    @property
+    def xml(self):
+        """
+        Returns the passage as XML
+        """
+        return self.textual_node().export(Mimetypes.XML.TEI)
+
     def next(self):
         reference = self.textual_node().nextId
         if reference:

--- a/scaife_viewer/urls.py
+++ b/scaife_viewer/urls.py
@@ -27,6 +27,7 @@ api_patterns = (
         path("library/vector/<str:urn>/", LibraryCollectionVectorView.as_view(), name="library_collection_vector"),
         path("library/passage/<str:urn>/json/", LibraryPassageView.as_view(format="json"), name="library_passage"),
         path("library/passage/<str:urn>/text/", LibraryPassageView.as_view(format="text"), name="library_passage_text"),
+        path("library/passage/<str:urn>/xml/", LibraryPassageView.as_view(format="xml"), name="library_passage_xml"),
         path("library/<str:urn>/json/", LibraryCollectionView.as_view(format="json"), name="library_collection"),
         path("search/json/", search_json, name="search"),
         path("morpheus/", morpheus, name="morpheus"),

--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -158,6 +158,7 @@ class LibraryPassageView(LibraryConditionMixin, View):
         to_response = {
             "json": self.as_json,
             "text": self.as_text,
+            "xml": self.as_xml,
         }.get(self.format, "json")
         return to_response()
 
@@ -190,6 +191,12 @@ class LibraryPassageView(LibraryConditionMixin, View):
         return HttpResponse(
             f"{self.passage.content}\n",
             content_type="text/plain; charset=utf-8",
+        )
+
+    def as_xml(self):
+        return HttpResponse(
+            f"{self.passage.xml}",
+            content_type="application/xml",
         )
 
 

--- a/static/src/js/reader/Reader.vue
+++ b/static/src/js/reader/Reader.vue
@@ -99,6 +99,7 @@
         </template>
         <template slot="right">
           <widget-passage-links />
+          <widget-passage-exports />
           <widget-text-mode />
           <widget-text-size />
           <widget-highlight />
@@ -127,6 +128,7 @@ import WidgetPassageReference from './widgets/WidgetPassageReference.vue';
 import WidgetSearch from './widgets/WidgetSearch.vue';
 import WidgetHighlight from './widgets/WidgetHighlight.vue';
 import WidgetPassageLinks from './widgets/WidgetPassageLinks.vue';
+import WidgetPassageExports from './widgets/WidgetPassageExports.vue';
 import WidgetTextMode from './widgets/WidgetTextMode.vue';
 import WidgetTextSize from './widgets/WidgetTextSize.vue';
 import WidgetMorpheus from './widgets/WidgetMorpheus.vue';
@@ -140,6 +142,7 @@ const widgets = {
   WidgetPassageReference,
   WidgetSearch,
   WidgetPassageLinks,
+  WidgetPassageExports,
   WidgetTextMode,
   WidgetTextSize,
   WidgetHighlight,

--- a/static/src/js/reader/Reader.vue
+++ b/static/src/js/reader/Reader.vue
@@ -99,10 +99,10 @@
         </template>
         <template slot="right">
           <widget-passage-links />
-          <widget-passage-exports />
           <widget-text-mode />
           <widget-text-size />
           <widget-highlight />
+          <widget-passage-exports />
           <widget-morpheus />
           <widget-token-list />
           <widget-word-list />

--- a/static/src/js/reader/widgets/WidgetPassageExports.vue
+++ b/static/src/js/reader/widgets/WidgetPassageExports.vue
@@ -1,0 +1,61 @@
+<template>
+  <base-widget class="passage-exports">
+    <span slot="header">Export Passage</span>
+    <div slot="body">
+      <template v-if="rightPassage">
+        <p>
+          <span class="side">L</span>
+          <span class="links">
+            as
+            <a :href="getPassageUrl(leftPassage, 'text')">text</a>
+            or
+            <a :href="getPassageUrl(leftPassage, 'xml')">xml</a>
+          </span>
+        </p>
+        <p>
+          <span class="side">R</span>
+          <span class="links">
+            as
+            <a :href="getPassageUrl(rightPassage, 'text')">text</a>
+            or
+            <a :href="getPassageUrl(rightPassage, 'xml')">xml</a>
+          </span>
+        </p>
+      </template>
+      <template v-else>
+        <p>
+          <span class="links">
+            as
+            <a :href="getPassageUrl(passage, 'text')">text</a>
+            or
+            <a :href="getPassageUrl(passage, 'xml')">xml</a>
+          </span>
+        </p>
+      </template>
+    </div>
+  </base-widget>
+</template>
+
+<script>
+const baseURL = `${process.env.FORCE_SCRIPT_NAME}` || "";
+
+export default {
+  name: "widget-passage-exports",
+  methods: {
+    getPassageUrl(passage, format) {
+      return `${baseURL}/library/passage/${passage.urn.toString()}/${format}/`;
+    },
+  },
+  computed: {
+    passage() {
+      return this.$store.getters["reader/passage"];
+    },
+    leftPassage() {
+      return this.$store.state.reader.leftPassage;
+    },
+    rightPassage() {
+      return this.$store.state.reader.rightPassage;
+    }
+  }
+};
+</script>

--- a/static/src/scss/_widget.scss
+++ b/static/src/scss/_widget.scss
@@ -91,6 +91,32 @@
     }
   }
 }
+
+.widget.passage-exports {
+  div.body {
+    font-size: 14px;
+    line-height: 16px;
+    p {
+      margin-left: 22px;
+      display: flex;
+      .side {
+        @extend .badge;
+        color: $gray-600;
+        background: $gray-100;
+        margin-right: 0.5em;
+      }
+      margin-bottom: 0.5rem;
+      .links {
+        font-style: italic;
+        color: $gray-600;
+        a {
+          font-style: normal;
+        }
+      }
+    }
+  }
+}
+
 .widget.selected-word {
   div.body {
     font-family: 'Noto Serif';


### PR DESCRIPTION
#### What does this PR do?

Adds a new widget that allows users to easily export the selected passage to plain text or XML formats.

#### Where should the reviewer start?

`WidgetPassageExports`

#### How should this be manually tested?

- Browse to `/reader/urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7/`
- Add a parallel version
- Export using the links for the "L" and "R" versions of the passage
- Remove the parallel version
- Export using the "text" and "xml" links

#### Any background context you want to provide?

`WidgetPassageLinks` isn't usable if the SV deployment is relying on the local resolver.

The new widget is useful for both local and api resolvers, as SV's XML output is more simplified than the XML doc returned by the CTS API.

#### What ticket or issue # does this fix?

Satisfies #246

#### Screenshot

![image](https://user-images.githubusercontent.com/629062/55756916-4bdcfe80-5a18-11e9-8f01-ab80dd946bcc.png)

