### PR TITLE
Precompute library json

### DIFF
--- a/scaife_viewer/apps.py
+++ b/scaife_viewer/apps.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 
 from django.apps import AppConfig as BaseAppConfig
+from django.conf import settings
 
 
 class AppConfig(BaseAppConfig):
@@ -9,3 +10,10 @@ class AppConfig(BaseAppConfig):
 
     def ready(self):
         import_module("scaife_viewer.receivers")
+
+        if settings.DEBUG is False:
+            # calling this will prime the cache in the master process. each fork
+            # will inherit it. gunicorn --preload is required for this to work.
+            precomputed = import_module("scaife_viewer.precomputed")
+            precomputed.library_view_json()
+            print("Precomputed library view JSON")

--- a/scaife_viewer/precomputed.py
+++ b/scaife_viewer/precomputed.py
@@ -1,0 +1,30 @@
+"""
+This module is used to pre-compute expensive operations when the web server boots up.
+"""
+from django.core.cache import cache
+
+from . import cts
+from .utils import apify
+
+
+def library_view_json():
+    key = "library-view-json"
+    data = cache.get(key, None)
+    if data is None:
+        all_text_groups = cts.text_inventory().text_groups()
+        text_groups = []
+        works = []
+        texts = []
+        for text_group in all_text_groups:
+            for work in text_group.works():
+                works.append(work)
+                for text in work.texts():
+                    texts.append(text)
+            text_groups.append(text_group)
+        data = {
+            "text_groups": [apify(text_group) for text_group in text_groups],
+            "works": [apify(work) for work in works],
+            "texts": [apify(text, with_toc=False) for text in texts],
+        }
+        cache.set(key, data, None)
+    return data

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -268,6 +268,7 @@ SECURE_REDIRECT_EXEMPT = [
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "sv-cache",
     },
 }
 

--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -307,5 +307,5 @@ if FORCE_SCRIPT_NAME:
 
 ELASTICSEARCH_HOSTS = os.environ.get("ELASTICSEARCH_HOSTS", "localhost").split(",")
 # https://elasticsearch-py.readthedocs.io/en/master/#sniffing
-ELASTICSEARCH_SNIFF_ON_START = DEBUG = bool(int(os.environ.get("ELASTICSEARCH_SNIFF_ON_START", "0")))
-ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL = DEBUG = bool(int(os.environ.get("ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL", "0")))
+ELASTICSEARCH_SNIFF_ON_START = bool(int(os.environ.get("ELASTICSEARCH_SNIFF_ON_START", "0")))
+ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL = bool(int(os.environ.get("ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL", "0")))

--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -19,6 +19,7 @@ import requests
 
 from . import cts
 from .http import ConditionMixin
+from .precomputed import library_view_json
 from .search import SearchQuery
 from .utils import apify, encode_link_header, get_pagination_info, link_passage
 
@@ -69,22 +70,8 @@ class LibraryView(LibraryConditionMixin, BaseLibraryView):
         return render(self.request, "library/index.html", {})
 
     def as_json(self):
-        all_text_groups = cts.text_inventory().text_groups()
-        text_groups = []
-        works = []
-        texts = []
-        for text_group in all_text_groups:
-            for work in text_group.works():
-                works.append(work)
-                for text in work.texts():
-                    texts.append(text)
-            text_groups.append(text_group)
-        payload = {
-            "text_groups": [apify(text_group) for text_group in text_groups],
-            "works": [apify(work) for work in works],
-            "texts": [apify(text, with_toc=False) for text in texts],
-        }
-        return JsonResponse(payload)
+        data = library_view_json()
+        return JsonResponse(data)
 
 
 class LibraryInfoView(View):

--- a/scaife_viewer/wsgi.py
+++ b/scaife_viewer/wsgi.py
@@ -14,11 +14,18 @@ from django.core.wsgi import get_wsgi_application
 
 def setup():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scaife_viewer.settings")
-    from . import cts
-    # calling this will prime the cache in the master process. each fork
-    # will inherit it. gunicorn --preload is required for this to work.
-    cts.TextInventory.load()
-    print("Loaded text inventory")
+    from django.conf import settings
+
+    from . import cts, precomputed
+
+    if settings.DEBUG is False:
+        # calling this will prime the cache in the master process. each fork
+        # will inherit it. gunicorn --preload is required for this to work.
+        cts.TextInventory.load()
+        print("Loaded text inventory")
+
+        precomputed.library_view_json()
+        print("Precomputed library view JSON")
 
 
 def healthz(app):

--- a/scaife_viewer/wsgi.py
+++ b/scaife_viewer/wsgi.py
@@ -15,17 +15,13 @@ from django.core.wsgi import get_wsgi_application
 def setup():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scaife_viewer.settings")
     from django.conf import settings
-
-    from . import cts, precomputed
+    from . import cts
 
     if settings.DEBUG is False:
         # calling this will prime the cache in the master process. each fork
         # will inherit it. gunicorn --preload is required for this to work.
         cts.TextInventory.load()
         print("Loaded text inventory")
-
-        precomputed.library_view_json()
-        print("Precomputed library view JSON")
 
 
 def healthz(app):


### PR DESCRIPTION
Precomputes the JSON payload returned by `library` during the web worker startup.

Currently, we're using an in-memory cache for this data, but in the future we might move to a shared Redis cache.

Resolves #354