### PR TITLE
improve the text width

### DIFF
--- a/static/src/js/reader/Reader.vue
+++ b/static/src/js/reader/Reader.vue
@@ -74,7 +74,7 @@
                   </template>
                 </div>
               </template>
-              <div v-else>
+              <div class="single" v-else>
                 <div v-if="leftPassage.error" class="alert text-danger" role="alert">
                   Failed to load <b>{{ leftPassage.urn.toString() }}</b>: {{ leftPassage.error }}
                 </div>

--- a/static/src/js/reader/widgets/WidgetTextWidth.vue
+++ b/static/src/js/reader/widgets/WidgetTextWidth.vue
@@ -5,6 +5,7 @@
       <span :class="['text-width-control', {active: textWidth == 'narrow'}]" @click="changetextWidth('narrow')">Narrow</span>
       <span :class="['text-width-control', {active: textWidth == 'normal'}]" @click="changetextWidth('normal')">Normal</span>
       <span :class="['text-width-control', {active: textWidth == 'wide'}]" @click="changetextWidth('wide')">Wide</span>
+      <span :class="['text-width-control', {active: textWidth == 'full'}]" @click="changetextWidth('full')">Full</span>
     </div>
   </base-widget>
 </template>

--- a/static/src/scss/_reader.scss
+++ b/static/src/scss/_reader.scss
@@ -69,8 +69,12 @@ body.reader {
     }
   }
 
+  .single {
+    flex: 4;
+  }
   .pg-left, .pg-right {
     flex: 1;
+    max-width: 100px;
     min-height: calc(100vh - 250px);
     a {
       display: block;

--- a/static/src/scss/_textwidth.scss
+++ b/static/src/scss/_textwidth.scss
@@ -1,12 +1,16 @@
-.text-width-normal {
-  max-width: 40em;
-}
-
 .text-width-narrow {
   max-width: 30em;
 }
 
+.text-width-normal {
+  max-width: 40em;
+}
+
 .text-width-wide {
+  max-width: 50em;
+}
+
+.text-width-full {
   max-width: 100%;
 }
 

--- a/static/src/scss/_textwidth.scss
+++ b/static/src/scss/_textwidth.scss
@@ -1,9 +1,9 @@
 .text-width-normal {
-  max-width: 90%;
+  max-width: 40em;
 }
 
 .text-width-narrow {
-  max-width: 80%;
+  max-width: 30em;
 }
 
 .text-width-wide {

--- a/test/WidgetTextWidth.spec.js
+++ b/test/WidgetTextWidth.spec.js
@@ -19,7 +19,7 @@ describe('WidgetTextWidth.vue', () => {
     });
     const normalSpan = wrapper.findAll('span').at(2);
 
-    expect(wrapper.text()).toBe('Text Width Narrow Normal Wide');
+    expect(wrapper.text()).toBe('Text Width Narrow Normal Wide Full');
     expect(normalSpan.html()).toBe('<span class="text-width-control active">Normal</span>');
     expect(store.state.reader.textWidth).toBe('normal');
   });


### PR DESCRIPTION
This PR greatly improves the text width by:

* making the Narrow, Normal and Wide cases em-based (30em, 40em and 50em respectively)
* adding a new option Full for the 100% width case
* giving the central text div a higher flex-grow so it is more willing to take up the available space
* giving the pagination regions a max-width of 100px