### PR TITLE
Improve performance by reducing table of contents generation

### DIFF
--- a/scaife_viewer/cts/collections.py
+++ b/scaife_viewer/cts/collections.py
@@ -93,7 +93,7 @@ class TextGroup(Collection):
                 continue
             yield work
 
-    def as_json(self) -> dict:
+    def as_json(self, **kwargs) -> dict:
         return {
             "urn": str(self.urn),
             "label": str(self.label),
@@ -127,7 +127,7 @@ class Work(Collection):
             texts.append(resolve_collection(metadata.TYPE_URI)(urn, metadata))
         yield from sorted(texts, key=attrgetter("kind", "label"))
 
-    def as_json(self) -> dict:
+    def as_json(self, **kwargs) -> dict:
         return {
             "urn": str(self.urn),
             "label": str(self.label),
@@ -196,7 +196,8 @@ class Text(Collection):
         if chunk is not None:
             return Passage(self, URN(chunk.urn).reference)
 
-    def as_json(self, with_toc=True) -> dict:
+    def as_json(self, **kwargs) -> dict:
+        with_toc = kwargs.pop("with_toc", False)
         payload = {
             "urn": str(self.urn),
             "label": str(self.label),

--- a/scaife_viewer/precomputed.py
+++ b/scaife_viewer/precomputed.py
@@ -24,7 +24,7 @@ def library_view_json():
         data = {
             "text_groups": [apify(text_group) for text_group in text_groups],
             "works": [apify(work) for work in works],
-            "texts": [apify(text, with_toc=False) for text in texts],
+            "texts": [apify(text) for text in texts],
         }
         cache.set(key, data, None)
     return data

--- a/scaife_viewer/utils.py
+++ b/scaife_viewer/utils.py
@@ -48,7 +48,7 @@ def apify(obj, **kwargs):
             "texts": [{**link_collection(text["urn"]), **text} for text in texts],
         }
     if isinstance(obj, cts.Text):
-        if kwargs.get("with_toc", True):
+        if kwargs.get("with_toc", False):
             first_passage = remaining.pop("first_passage")
             ancestors = remaining.pop("ancestors")
             toc = remaining.pop("toc")

--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -104,10 +104,22 @@ class LibraryCollectionView(LibraryConditionMixin, BaseLibraryView):
         }
         return render(self.request, f"library/cts_{collection_name}.html", ctx)
 
-    def as_json(self):
+    def should_toc(self, collection_obj):
+        """
+        Only invoke TOC when the collection is a Text.
+        """
+        return isinstance(collection_obj, cts.Text)
+
+    @property
+    def json_paylod(self):
         collection = self.get_collection()
+        if self.should_toc:
+            return apify(collection, with_toc=True)
+        return apify(collection)
+
+    def as_json(self):
         try:
-            return JsonResponse(apify(collection))
+            return JsonResponse(self.json_paylod)
         except ValueError as e:
             """"
             TODO: good idea to refactor this to send back consistent error

--- a/static/src/js/library/CTSVersionList.vue
+++ b/static/src/js/library/CTSVersionList.vue
@@ -18,7 +18,7 @@
             <p class="card-text">{{ text.description }}</p>
           </div>
           <div class="card-footer">
-            <a :href="text.first_passage.url"><icon name="book"></icon> Read ({{ text.human_lang }})</a>
+            <a :href="text.reader_url"><icon name="book"></icon> Read ({{ text.human_lang }})</a>
           </div>
         </div>
       </div>

--- a/static/src/js/library/CTSWorkList.vue
+++ b/static/src/js/library/CTSWorkList.vue
@@ -35,7 +35,7 @@
               <p class="card-text">{{ text.description }}</p>
             </div>
             <div class="card-footer">
-              <a :href="text.first_passage.url"><icon name="book"></icon> Read ({{ text.human_lang }})</a>
+              <a :href="text.reader_url"><icon name="book"></icon> Read ({{ text.human_lang }})</a>
             </div>
           </div>
         </div>

--- a/static/src/js/vuex/library/actions.js
+++ b/static/src/js/vuex/library/actions.js
@@ -55,7 +55,7 @@ export default {
     let params = {
       e: textGroup.works.map(work => work.urn.replace(`${textGroup.urn}.`, '')),
     };
-    api.getLibraryVector(textGroup.urn, params, (worksVector) => {
+    return api.getLibraryVector(textGroup.urn, params, (worksVector) => {
       const workMap = worksVector.collections;
 
       const e = [];
@@ -68,7 +68,7 @@ export default {
       params = { e };
 
       // vector for texts
-      api.getLibraryVector(textGroup.urn, params, (textsVector) => {
+      return api.getLibraryVector(textGroup.urn, params, (textsVector) => {
         const textMap = textsVector.collections;
 
         // finally prepare the works object to store
@@ -104,7 +104,7 @@ export default {
     const params = {
       e: work.texts.map(text => text.urn.replace(`${work.urn}.`, '')),
     };
-    api.getLibraryVector(work.urn, params, (textsVector) => {
+    return api.getLibraryVector(work.urn, params, (textsVector) => {
       const textMap = textsVector.collections;
       const versions = work.texts.map(({ urn: textUrn }) => textMap[textUrn]);
       commit(constants.SET_VERSIONS, versions);


### PR DESCRIPTION
- Use `library_text_redirect` to lazily resolve the first passage when linking from the work or version library pages.
- Ensure promises are resolved correctly.  We were prematurely removing the "loading" screens on  `CTSWorkList.vue` and `CTSVersionList.vue` before the axios callbacks were complete, which made the page appear to load even slower than it already was
- Refactor "TOC'ing" when apify'ing collections.  Since we're lazily resolving the first passages when showing the work or version lists, we never need to generate the table of contents (TOC).  We do, however, need to generate the TOC within `CTSTocList.vue`, so we retain the ability to do that.

Closes #390 