### PR TITLE
Fix search highlight regression

### DIFF
--- a/scaife_viewer/views.py
+++ b/scaife_viewer/views.py
@@ -332,7 +332,6 @@ def search_json(request):
             "scope": scope,
             "aggregate_fields": aggregate_fields,
             "kind": kind,
-            "fragments": 10000,
             "offset": (page_num - 1) * 10
         }
         try:


### PR DESCRIPTION
As alluded to in the comment I added for `ENTIRE_FIELD_CONTENTS`, we must always retrieve the entire passage content (raw content or lemma content) to ensure the highlighting is aligned properly with the passage tokens:

https://github.com/scaife-viewer/scaife-viewer/blob/859c14e2ac85f835c12cc2dd7edbf83669cc9299/scaife_viewer/search.py#L217

Resolves #388