### PR TITLE
Restore the ability to shift-click to select multiple terms in highlight mode

### DIFF
--- a/static/src/js/reader/InlineToken.vue
+++ b/static/src/js/reader/InlineToken.vue
@@ -16,15 +16,30 @@ export default {
       return `${this.w}[${this.i}]`;
     },
   },
+  methods: {
+    processTokenClick(evt, clickable, selected, idx) {
+      if (evt.metaKey && selected) {
+        // clear input
+        this.$store.dispatch(`reader/${constants.READER_SET_SELECTED_TOKEN}`, { token: null });
+      } else if (evt.shiftKey) {
+        // add to selection
+        this.$store.dispatch(`reader/${constants.READER_SELECT_TOKEN_RANGE}`, { token: idx });
+      } else {
+        // set selection
+        this.$store.dispatch(`reader/${constants.READER_SET_SELECTED_TOKEN}`, { token: idx });
+      }
+      evt.stopPropagation();
+    }
+  },
   render(h) {
     let selected = false;
     let highlighted = false;
     let clickable = false;
+    const vueInstance = this;
     const {
       t, idx, highlighting,
       $parent: p,
       $store: store,
-      $router: router
     } = this;
     const { visible } = p;
     if (visible && highlighting) {
@@ -46,19 +61,7 @@ export default {
         on: {
           click(e) {
             if (clickable) {
-              let value = idx;
-              if (e.metaKey) {
-                if (selected) {
-                  value = null;
-                }
-              }
-              store.dispatch(`reader/${constants.READER_SET_SELECTED_TOKEN}`, { token: value });
-              router.replace({
-                query: {
-                  highlight: value
-                }
-              });
-              e.stopPropagation();
+              vueInstance.processTokenClick(e, clickable, selected, idx);
             }
           },
         },

--- a/static/src/js/reader/widgets/WidgetHighlight.vue
+++ b/static/src/js/reader/widgets/WidgetHighlight.vue
@@ -43,6 +43,19 @@ export default {
   methods: {
     setInputVal() {
       this.value = this.highlight;
+      this.updateHighlightQueryParam();
+    },
+    updateHighlightQueryParam() {
+      /*
+        Since the `highlight` computed property is reactive, when
+        `$store.state.reader.highlight` is changed, the widget will
+        update the `highlight` query param
+      */
+      this.$router.replace({
+        query: {
+          highlight: this.value,
+        },
+      });
     },
     handleKeyUp(e) {
       if (e.keyCode === 13) {
@@ -52,11 +65,6 @@ export default {
           this.$store.dispatch(`reader/${constants.READER_HIGHLIGHT}`, { highlight: this.value });
         }
         e.currentTarget.blur();
-        this.$router.replace({
-          query: {
-            highlight: this.value,
-          }
-        });
       } else {
         e.stopPropagation();
       }


### PR DESCRIPTION
Closes #423

Rather than changing the router within the store (https://github.com/scaife-viewer/scaife-viewer/blob/a02eff8d7fccb62173dafd975d0743e5dc43920e/static/src/js/reader/store.js#L384), I've opted to use the existing watcher within the widget.