### PR TITLE
Fix webpack loader config to work correctly with manifest storage backends

### DIFF
--- a/scaife_viewer/settings.py
+++ b/scaife_viewer/settings.py
@@ -82,7 +82,7 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 if "SECRET_KEY" in os.environ:
     SECRET_KEY = os.environ["SECRET_KEY"]
@@ -176,7 +176,7 @@ INSTALLED_APPS = [
 WEBPACK_LOADER = {
     "DEFAULT": {
         "CACHE": not DEBUG,
-        "BUNDLE_DIR_NAME": "/",
+        "BUNDLE_DIR_NAME": "",
         "STATS_FILE": os.path.join(PROJECT_ROOT, "static", "stats", "webpack-stats.json"),
         "POLL_INTERVAL": 0.1,
         "TIMEOUT": None,


### PR DESCRIPTION
We'd previously tried to use `CompressedManifestStaticFilesStorage` with this project, but hit an issue with how `django-webpack-loader` kept track of webpack's own hashing of static assets.

I dug into the source code for `whitenoise` and `django-webpack-loader` and came up with this configuration tweak, which resolves the issue.