### PR TITLE
Extract / ingest repo metadata

### DIFF
--- a/bin/fetch_corpus_repo_metadata
+++ b/bin/fetch_corpus_repo_metadata
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# NOTE: This script should be ran before ingesting data into ATLAS
+
+DATA_DIR=${ATLAS_DATA_DIR:-atlas_data}
+REPO_METADATA_DIR=${DATA_DIR}/annotations/repo-metadata
+CORPUS_METADATA_ENDPOINT=${CORPUS_METADATA_ENDPOINT-https://scaife-cts-dev.perseus.org/corpus-metadata}
+
+mkdir -p ${REPO_METADATA_DIR}
+
+curl -s "${CORPUS_METADATA_ENDPOINT}" > ${REPO_METADATA_DIR}/corpus-metadata.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ requests==2.22.0
 # @@@ atlas package is not yet released to pypi
 scaife-viewer-atlas @https://github.com/scaife-viewer/backend/archive/d1cee5854eb0b531a63c475261dc04f4a3a948fa.zip#subdirectory=atlas
 # @@@ core package is not yet released to pypi
-scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/4cf714d4b1661ba1f793d12b0fa1346f7e2d9946.zip#subdirectory=core
+scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/af084444970bd35947e42bbabbe4e59ae0e53730.zip#subdirectory=core
 six==1.12.0
 whitenoise==4.1.2


### PR DESCRIPTION
- Updates `load_text_repos` management command to provide parity with scaife-viewer/scaife-cts-api#17
- Bump to latest core package to extract repo metadata
- Add shell script to copy repo metadata for ingestion
- Bump to latest ATLAS package to ingest metadata