### PR TITLE
Prepare for v2021-11-29-001 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15894,9 +15894,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-arraybuffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5908,9 +5908,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
+      "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11436,9 +11436,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.5.tgz",
-      "integrity": "sha512-gWJOWYFrhQ8j7pVm0EM8Slr+EPVq1Phf6lvzvD/WCeqkrx/f2xBI0xOsRRS9xCn3I4vKtP519dvs3TP09r24wQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16728,9 +16728,9 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
@@ -17294,9 +17294,9 @@
           "dev": true
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
@@ -17477,9 +17477,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4782,17 +4782,17 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
+      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       },
       "dependencies": {
         "follow-redirects": {
-          "version": "1.13.3",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-          "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+          "version": "1.14.5",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.21.1",
     "bootstrap": "^4.4.1",
     "dayjs": "^1.8.18",
-    "json-schema": "^0.2.5",
+    "json-schema": "^0.4.0",
     "keykey": "^2.1.1",
     "loaders.css": "^0.1.2",
     "lodash.chunk": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@scaife-viewer/widget-attributions": "https://gitpkg.now.sh/scaife-viewer/frontend/packages/widget-attributions?8d4196f2a6617e667f3c51998c1216527a82b502",
     "@scaife-viewer/widget-repo-metadata": "https://gitpkg.now.sh/scaife-viewer/frontend/packages/widget-repo-metadata?8d4196f2a6617e667f3c51998c1216527a82b502",
     "@scaife-viewer/widget-new-alexandria": "https://gitpkg.now.sh/scaife-viewer/frontend/packages/widget-new-alexandria?b48935fa4737773a8d1b8460c75660ba26f3e0c9",
-    "axios": "^0.21.1",
+    "axios": "^0.21.2",
     "bootstrap": "^4.4.1",
     "dayjs": "^1.8.18",
     "json-schema": "^0.4.0",

--- a/sv_pdl/stats/library_stats.json
+++ b/sv_pdl/stats/library_stats.json
@@ -1,13 +1,13 @@
 {
   "text_counts": {
     "grc": 1583,
-    "lat": 643,
-    "total": 3145
+    "lat": 642,
+    "total": 3144
   },
   "word_counts": {
-    "grc": 31397090,
+    "grc": 31396704,
     "lat": 16752562,
-    "total": 69374990
+    "total": 69374604
   },
   "works_count": 2356
 }

--- a/sv_pdl/templates/homepage.html
+++ b/sv_pdl/templates/homepage.html
@@ -62,6 +62,22 @@
         <div class="col-md-6">
           <h2>Recent Changes</h2>
 
+          <h3>week of November 29th, 2021</h3>
+
+          <ul>
+            <li>updated corpora and corpora stats</li>
+          </ul>
+
+          <div class="ml-4">
+            <a href="https://github.com/scaife-viewer/scaife-viewer/releases/tag/v2021-11-29-001">
+            <small>
+              (v2021-11-29-001 release)
+            </small>
+            </a>
+          </div>
+
+          <hr />
+
           <h3>week of October 25th, 2021</h3>
 
           <ul>
@@ -88,22 +104,6 @@
             <a href="https://github.com/scaife-viewer/scaife-viewer/releases/tag/v2021-10-01-001">
             <small>
               (v2021-10-01-001 release)
-            </small>
-            </a>
-          </div>
-
-          <hr />
-
-          <h3>week of August 30th, 2021</h3>
-
-          <ul>
-            <li>updated corpora and corpora stats</li>
-          </ul>
-
-          <div class="ml-4">
-            <a href="https://github.com/scaife-viewer/scaife-viewer/releases/tag/v2021-09-03-001">
-            <small>
-              (v2021-09-03-001 release)
             </small>
             </a>
           </div>


### PR DESCRIPTION
## Features
- Update corpora to [scaife-cts-api@v0.3.1_20211129_001](https://github.com/scaife-viewer/scaife-cts-api/releases/tag/v0.3.1_20211129_001)

## Fixes
- Update endpoint used by New Alexandria Commentary widget

## Other improvements
- Update frontend deps from dependabot PRs