### PR TITLE
Set a 'nofile' limit for elasticsearch

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       memlock:
         soft: -1
         hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
     ports:
       - 9200:9200
     volumes:


### PR DESCRIPTION
On some systems, the default `nofile` limit is below elastic's minimum of 65536. This causes elastic search to fail during its bootstrap check.

This PR sets a `nofile`  limit of 65536, the minimum.