### PR TITLE
Set up GitHub actions to deploy new code and content

### DIFF
--- a/.github/workflows/build-artifacts-image.yml
+++ b/.github/workflows/build-artifacts-image.yml
@@ -24,13 +24,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Autogenerate webapp Docker image tags
+        id: autogen-docker-tags
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: ghcr.io/${{ github.repository }}/artifacts
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build artifacts image
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: deploy/artifacts/prepare-artifacts.dockerfile
-          tags:
-            ghcr.io/${{ github.repository }}/artifacts:latest
+          tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           build-args:
             WEBAPP_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-base:latest
           push: true

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -24,6 +24,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Autogenerate webapp Docker image tags
+        id: autogen-docker-tags
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: ghcr.io/${{ github.repository }}/webapp-base
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build base image
         uses: docker/build-push-action@v2
         with:
@@ -31,6 +45,5 @@ jobs:
           cache-to: type=gha,mode=max
           context: ./
           file: deploy/webapp/webapp-base.dockerfile
-          tags:
-            ghcr.io/${{ github.repository }}/webapp-base:latest
+          tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           push: true

--- a/.github/workflows/build-deployment-image.yml
+++ b/.github/workflows/build-deployment-image.yml
@@ -2,11 +2,24 @@ name: Build deployment image
 
 on:
   workflow_dispatch:
+    inputs:
+      artifacts_image:
+        description: Artifacts Docker image (optional)
+        type: string
+        required: false
+      webapp_image:
+        description: Webapp Base Docker image (optional)
+        type: string
+        required: false
 
 jobs:
   build-images:
     name: Build deployment image and push image tags
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_ARTIFACTS_IMAGE: ghcr.io/${{ github.repository }}/artifacts:latest
+      DEFAULT_WEBAPP_IMAGE: ghcr.io/${{ github.repository }}/webapp-base:latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,7 +58,7 @@ jobs:
           file: deploy/webapp/webapp-deploy.dockerfile
           tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           build-args: |
-            WEBAPP_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-base:latest
-            ARTIFACTS_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/artifacts:latest
+            WEBAPP_DOCKER_IMAGE=${{ github.event.inputs.webapp_image || env.DEFAULT_WEBAPP_IMAGE }}
+            ARTIFACTS_DOCKER_IMAGE=${{ github.event.inputs.artifacts_image || env.DEFAULT_ARTIFACTS_IMAGE }}
             GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}
           push: true

--- a/.github/workflows/build-deployment-image.yml
+++ b/.github/workflows/build-deployment-image.yml
@@ -24,13 +24,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Autogenerate webapp Docker image tags
+        id: autogen-docker-tags
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: ghcr.io/${{ github.repository }}/webapp-deploy
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build deployment image
         uses: docker/build-push-action@v4
         with:
           context: ./
           file: deploy/webapp/webapp-deploy.dockerfile
-          tags:
-            ghcr.io/${{ github.repository }}/webapp-deploy:latest
+          tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           build-args: |
             WEBAPP_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-base:latest
             ARTIFACTS_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/artifacts:latest

--- a/.github/workflows/build-search-image.yml
+++ b/.github/workflows/build-search-image.yml
@@ -33,5 +33,5 @@ jobs:
           tags:
             ghcr.io/${{ github.repository }}/indexer:latest
           build-args: |
-            WEBAPP_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-base:latest
+            WEBAPP_DEPLOY_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-deploy:latest
           push: true

--- a/.github/workflows/build-search-image.yml
+++ b/.github/workflows/build-search-image.yml
@@ -2,11 +2,19 @@ name: Build search indexer image
 
 on:
   workflow_dispatch:
+    inputs:
+      deployment_image:
+        description: Deployment Docker image (optional)
+        type: string
+        required: false
 
 jobs:
   build-images:
     name: Build search indexer image and push image tags
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_DEPLOYMENT_IMAGE: ghcr.io/${{ github.repository }}/webapp-deploy:latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,5 +54,5 @@ jobs:
           file: deploy/search-index/search-index.dockerfile
           tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           build-args: |
-            WEBAPP_DEPLOY_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-deploy:latest
+            WEBAPP_DEPLOY_DOCKER_IMAGE=${{ github.event.inputs.deployment_image || env.DEFAULT_DEPLOYMENT_IMAGE }}
           push: true

--- a/.github/workflows/build-search-image.yml
+++ b/.github/workflows/build-search-image.yml
@@ -24,14 +24,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Autogenerate webapp Docker image tags
+        id: autogen-docker-tags
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: ghcr.io/${{ github.repository }}/indexer
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+
       # TODO: Push to gcr.io and rebuild the search index
       - name: Build search indexer image
         uses: docker/build-push-action@v4
         with:
           context: ./
           file: deploy/search-index/search-index.dockerfile
-          tags:
-            ghcr.io/${{ github.repository }}/indexer:latest
+          tags: ${{ steps.autogen-docker-tags.outputs.tags }}
           build-args: |
             WEBAPP_DEPLOY_DOCKER_IMAGE=ghcr.io/${{ github.repository }}/webapp-deploy:latest
           push: true

--- a/.github/workflows/delete-indices.yml
+++ b/.github/workflows/delete-indices.yml
@@ -1,0 +1,15 @@
+name: Delete indices
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+      name: Delete indices
+      runs-on: ubuntu-latest
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        HEROKU_APP: scaife-perseus-org
+      steps:
+        - name: Run cleanup_search_indices command
+          run: heroku run python manage.py cleanup_search_indices --force

--- a/.github/workflows/delete-indices.yml
+++ b/.github/workflows/delete-indices.yml
@@ -12,4 +12,4 @@ jobs:
         HEROKU_APP: scaife-perseus-org
       steps:
         - name: Run cleanup_search_indices command
-          run: heroku run python manage.py cleanup_search_indices --force
+          run: heroku run --exit-code python manage.py cleanup_search_indices --force

--- a/.github/workflows/diff-corpora-contents.yml
+++ b/.github/workflows/diff-corpora-contents.yml
@@ -1,0 +1,27 @@
+name: Diff corpora contents
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diff-corpora-contents:
+    name: Diff two versions of the corpus-metadata manifest
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    # TODO: Simplify via webapp-base docker image
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: pip install pip wheel --upgrade
+    - name: Install scaife-cli and dependencies
+      run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/8ca4c2e2328a7deaeb41fa3f388943d1a4c24328.zip#subdirectory=core" PyGithub
+    - name: Diff corpora contents
+      run: |
+        scaife diff-corpora-contents > diff.patch
+        echo 'Copying diff.patch to step summary'
+        printf '```\n```diff\n' > $GITHUB_STEP_SUMMARY
+        cat diff.patch >> $GITHUB_STEP_SUMMARY
+        printf '```\n```\n' >> $GITHUB_STEP_SUMMARY
+        cat $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-index.yml
+++ b/.github/workflows/promote-index.yml
@@ -1,0 +1,24 @@
+name: Promote search index
+
+on:
+  workflow_dispatch:
+    inputs:
+      indexName:
+        description: 'Name of the latest search index'
+        required: true
+      herokuAppName:
+        description: 'Heroku app'
+        required: true
+        default: scaife-perseus-org-dev
+
+jobs:
+  promote:
+      name: Promote search index
+      runs-on: ubuntu-latest
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        HEROKU_APP: ${{ github.event.inputs.herokuAppName }}
+        ELASTICSEARCH_INDEX_NAME: ${{ github.event.inputs.indexName }}
+      steps:
+        - name: Release
+          run: heroku config:set ELASTICSEARCH_INDEX_NAME=${ELASTICSEARCH_INDEX_NAME}

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -36,6 +36,8 @@ jobs:
         export ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)"
         echo $ELASTICSEARCH_INDEX_NAME
 
+        gcloud components install beta --quiet
+
         gcloud --project=scaife-viewer beta run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
 
         gcloud beta run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -28,7 +28,5 @@ jobs:
       run: |
         gcr.io/scaife-viewer/scaife-viewer/indexer:${DOCKER_IMAGE_TAG:-latest}
         docker pull ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
-        docker tag \
-          ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }} \
-          gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
+        docker tag ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }} gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
         docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -48,7 +48,7 @@ jobs:
     # TODO: Make ELASTICSEARCH_INDEX_NAME an output value to trigger a downstream deployment job
     - name: Configure and run reindexing job
       run: |
-        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=${GCR_IMAGE}
+        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=${GCR_IMAGE} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
 
         gcloud --project=scaife-viewer run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async
     - name: Echo $ELASTICSEARCH_INDEX_NAME

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -3,15 +3,18 @@ name: Reindex content
 on:
   workflow_dispatch:
     inputs:
-      imageTag:
-        description: 'Tag to use for the search indexer image'
-        required: true
-        default: latest
+      search_image:
+        description: Search Docker image (optional)
+        type: string
+        required: false
 
 jobs:
   reindex-content:
     name: Reindex content in ElasticSearch
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_SEARCH_IMAGE: ghcr.io/${{ github.repository }}/indexer:latest
+      GCR_IMAGE: gcr.io/${{ github.repository }}/indexer:${{ github.run_id }}
     steps:
     - name: Authenticate with Google
       id: 'google-auth'
@@ -31,10 +34,12 @@ jobs:
         echo '${{ github.token }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
         echo '${{ steps.google-auth.outputs.access_token }}' | docker login gcr.io -u oauth2accesstoken --password-stdin
     - name: Tag and push GCR image
+      env:
+        SEARCH_IMAGE: ${{ github.event.inputs.search_image || env.DEFAULT_SEARCH_IMAGE }}
       run: |
-        docker pull ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
-        docker tag ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }} gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
-        docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
+        docker pull ${SEARCH_IMAGE}
+        docker tag ${SEARCH_IMAGE} ${GCR_IMAGE}
+        docker push ${GCR_IMAGE}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
     - name: Set ELASTICSEARCH_INDEX_NAME
@@ -43,7 +48,7 @@ jobs:
     # TODO: Make ELASTICSEARCH_INDEX_NAME an output value to trigger a downstream deployment job
     - name: Configure and run reindexing job
       run: |
-        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${{ env.ELASTICSEARCH_INDEX_NAME }}"
+        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=${GCR_IMAGE}"
 
         gcloud --project=scaife-viewer run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async
     - name: Echo $ELASTICSEARCH_INDEX_NAME

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -36,11 +36,6 @@ jobs:
         export ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)"
         echo $ELASTICSEARCH_INDEX_NAME
 
-        gcloud --project=scaife-viewer beta run jobs --region=us-east4 update \
-            scaife-viewer-update-search-index-dev \
-            --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} \
-            --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
+        gcloud --project=scaife-viewer beta run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
 
-        gcloud beta run jobs --region=us-east4 execute \
-            scaife-viewer-update-search-index-dev \
-            --async
+        gcloud beta run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -18,6 +18,12 @@ jobs:
       uses: 'google-github-actions/auth@v0.4.4'
       with:
         # added via the sv-github-actions-sa Service Account
+        # NOTE: The following IAM roles are required
+        # - Artifact Registry Writer (not yet required, will be once we retire gcr.io)
+        # - Cloud Run Admin
+        # - Service Account Token Creator
+        # - Storage Admin
+        # - Service Account User
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
         token_format: 'access_token'
     - name: Login to GitHub and GCR container registries
@@ -31,13 +37,12 @@ jobs:
         docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
+    # TODO: Make ELASTICSEARCH_INDEX_NAME an output value to trigger a downstream deployment job
     - name: Configure and run reindexing job
       run: |
         export ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)"
         echo $ELASTICSEARCH_INDEX_NAME
 
-        gcloud components install beta --quiet
+        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
 
-        gcloud --project=scaife-viewer beta run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
-
-        gcloud beta run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async
+        gcloud --project=scaife-viewer run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -26,7 +26,6 @@ jobs:
         echo '${{ steps.google-auth.outputs.access_token }}' | docker login gcr.io -u oauth2accesstoken --password-stdin
     - name: Tag and push GCR image
       run: |
-        gcr.io/scaife-viewer/scaife-viewer/indexer:${DOCKER_IMAGE_TAG:-latest}
         docker pull ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
         docker tag ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }} gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
         docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -29,3 +29,18 @@ jobs:
         docker pull ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
         docker tag ghcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }} gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
         docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+    - name: Configure and run reindexing job
+      run: |
+        export ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)"
+        echo $ELASTICSEARCH_INDEX_NAME
+
+        gcloud --project=scaife-viewer beta run jobs --region=us-east4 update \
+            scaife-viewer-update-search-index-dev \
+            --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} \
+            --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
+
+        gcloud beta run jobs --region=us-east4 execute \
+            scaife-viewer-update-search-index-dev \
+            --async

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -37,12 +37,15 @@ jobs:
         docker push gcr.io/${{ github.repository }}/indexer:${{ github.event.inputs.imageTag }}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
+    - name: Set ELASTICSEARCH_INDEX_NAME
+      run: |
+        echo ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)" >> "$GITHUB_ENV"
     # TODO: Make ELASTICSEARCH_INDEX_NAME an output value to trigger a downstream deployment job
     - name: Configure and run reindexing job
       run: |
-        export ELASTICSEARCH_INDEX_NAME="scaife-viewer-$(date +%s)"
-        echo $ELASTICSEARCH_INDEX_NAME
-
-        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${ELASTICSEARCH_INDEX_NAME}"
+        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=gcr.io/scaife-viewer/scaife-viewer/indexer:${{ github.event.inputs.imageTag }} --args="--chunk-size=500,--index-name=${{ env.ELASTICSEARCH_INDEX_NAME }}"
 
         gcloud --project=scaife-viewer run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async
+    - name: Echo $ELASTICSEARCH_INDEX_NAME
+      run: |
+        echo "${{ env.ELASTICSEARCH_INDEX_NAME }}"

--- a/.github/workflows/reindex-content.yml
+++ b/.github/workflows/reindex-content.yml
@@ -48,7 +48,7 @@ jobs:
     # TODO: Make ELASTICSEARCH_INDEX_NAME an output value to trigger a downstream deployment job
     - name: Configure and run reindexing job
       run: |
-        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=${GCR_IMAGE}"
+        gcloud --project=scaife-viewer run jobs --region=us-east4 update scaife-viewer-update-search-index-dev --image=${GCR_IMAGE}
 
         gcloud --project=scaife-viewer run jobs --region=us-east4 execute scaife-viewer-update-search-index-dev --async
     - name: Echo $ELASTICSEARCH_INDEX_NAME

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -27,7 +27,15 @@ jobs:
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check for changes to content manifest
+      id: manifest_has_changes
+      run: |
+        git diff --quiet data/content-manifests/
+    # NOTE: manifest_has_changes returns a non-zero code if there are changes
+    # commit_and_push will only run if the previous step fails (e.g., there are changes)
     - name: Commit and push new branch
+      id: commit_and_push
+      if: ${{ steps.manifest_has_changes.conclusion == 'failure'  }}
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
@@ -36,7 +44,10 @@ jobs:
         git push
     # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
     # [√] Allow GitHub Actions to create and approve pull requests
+    # NOTE: Only runs when changes have been pushed
     - name: Create pull request
+      id: create-pr
+      if: ${{ steps.commit_and_push.conclusion == 'success'  }}
       run: gh pr create --fill
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -27,11 +27,7 @@ jobs:
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
     - name: Checkout the content branch
       run: |
-        git checkout -B ${{ env.CONTENT_BRANCH }}
-    - name: Pull changes from the named remote branch
-      continue-on-error: true
-      run: |
-        git pull origin gh-actions/update-content-manifest --ff-only
+        git switch -c ${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -35,6 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Check for changes to content manifest
       id: manifest_has_changes
+      continue-on-error: true
       run: |
         git diff --quiet data/content-manifests/
     # NOTE: manifest_has_changes returns a non-zero code if there are changes

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -5,7 +5,9 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # NOTE: See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron:  '0 12 * * *'
+    # > To decrease the chance of delay, schedule your workflow to run at a different time of the hour.
+    # This is why we're targeting the 48th minute.
+    - cron:  '48 12 * * *'
 
 jobs:
   update-content-manifest:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -27,7 +27,8 @@ jobs:
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
     - name: Checkout the content branch
       run: |
-        git switch -c ${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
+        git fetch
+        git switch -c g${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -43,7 +43,7 @@ jobs:
     # TODO: Prevent overlapping branches; e.g. 2023-06-27, 2023-06-28, etc
     - name: Commit and push new branch
       id: commit_and_push
-      if: ${{ steps.manifest_has_changes.conclusion == 'failure'  }}
+      if: ${{ steps.manifest_has_changes.outcome == 'failure'  }}
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
@@ -55,11 +55,11 @@ jobs:
     # NOTE: Only runs when changes have been pushed
     - name: Create pull request
       id: create-pr
-      if: ${{ steps.commit_and_push.conclusion == 'success'  }}
+      if: ${{ steps.commit_and_push.outcome == 'success'  }}
       run: gh pr create --fill
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Report if no changes were detected
       id: no-changes-detected
-      if: ${{ steps.manifest_has_changes.conclusion == 'success'  }}
+      if: ${{ steps.manifest_has_changes.outcome == 'success'  }}
       run: echo 'No changes detected'

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -28,10 +28,12 @@ jobs:
     - name: Fetch branches
       run: git fetch
     - name: Checkout the existing content branch
+      id: checkout_existing_branch
       continue-on-error: true
       run: |
         git switch -c g${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
     - name: Checkout the non-existent content branch
+      if: ${{ steps.checkout_existing_branch.outcome == 'failure'  }}
       run: |
         git switch -c g${{ env.CONTENT_BRANCH }}
     - name: Update content manifest

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -13,6 +13,8 @@ jobs:
   update-content-manifest:
     name: Update the content manifest and push a commit to a new branch
     runs-on: ubuntu-latest
+    env:
+      CONTENT_BRANCH: gh-actions/update-content-manifest
 
     steps:
     - uses: actions/checkout@v3
@@ -28,7 +30,7 @@ jobs:
         echo "CONTENT_BRANCH=content-`date -I`" >> "$GITHUB_ENV"
     - name: Checkout a new branch
       run: |
-        git checkout -b ${{ env.CONTENT_BRANCH }}
+        git checkout -B ${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:
@@ -48,7 +50,7 @@ jobs:
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add data/content-manifests/production.yaml
-        git commit -m "Update corpora SHAs ${{ env.CONTENT_BRANCH }}"
+        git commit -m "Update corpora SHAs `date -I`"
         git push --set-upstream origin ${{ env.CONTENT_BRANCH }}
     # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
     # [√] Allow GitHub Actions to create and approve pull requests

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Pull changes from the named remote branch
       continue-on-error: true
       run: |
-        git pull origin gh-actions/update-content-manifest -ff
+        git pull origin gh-actions/update-content-manifest --ff-only
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -60,5 +60,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Report if no changes were detected
       id: no-changes-detected
-      if: ${{ steps.manifest_has_changes.conclusion == 'failure'  }}
+      if: ${{ steps.manifest_has_changes.conclusion == 'success'  }}
       run: echo 'No changes detected'

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -53,7 +53,7 @@ jobs:
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add data/content-manifests/production.yaml
         git commit -m "Update corpora SHAs `date -I`"
-        git push origin ${{ env.CONTENT_BRANCH }}
+        git push origin HEAD
     # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
     # [√] Allow GitHub Actions to create and approve pull requests
     # NOTE: Only runs when changes have been pushed

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -25,9 +25,6 @@ jobs:
     - run: pip install pip wheel --upgrade
     - name: Install scaife-cli and dependencies
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
-    - name: Create content branch env var
-      run: |
-        echo "CONTENT_BRANCH=content-`date -I`" >> "$GITHUB_ENV"
     - name: Checkout a new branch
       run: |
         git checkout -B ${{ env.CONTENT_BRANCH }}
@@ -42,7 +39,6 @@ jobs:
         git diff --quiet data/content-manifests/
     # NOTE: manifest_has_changes returns a non-zero code if there are changes
     # commit_and_push will only run if the previous step fails (e.g., there are changes)
-    # TODO: Prevent overlapping branches; e.g. 2023-06-27, 2023-06-28, etc
     - name: Commit and push new branch
       id: commit_and_push
       if: ${{ steps.manifest_has_changes.outcome == 'failure'  }}

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Update the content manifest and push a commit to a new branch
     runs-on: ubuntu-latest
     env:
-      CONTENT_BRANCH: gh-actions/update-content-manifest
+      CONTENT_BRANCH: gh-actions/update-content-manifest-test
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -25,6 +25,8 @@ jobs:
         git checkout -b ${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Commit and push new branch
       run: |
         git config user.name 'github-actions[bot]'

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -51,3 +51,7 @@ jobs:
       run: gh pr create --fill
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Report if no changes were detected
+      id: no-changes-detected
+      if: ${{ steps.manifest_has_changes.conclusion == 'failure'  }}
+      run: echo 'No changes detected'

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Update the content manifest and push a commit to a new branch
     runs-on: ubuntu-latest
     env:
-      CONTENT_BRANCH: gh-actions/update-content-manifest
+      CONTENT_BRANCH: gh-actions/update-content-manifest-debug
 
     steps:
     - uses: actions/checkout@v3
@@ -31,11 +31,11 @@ jobs:
       id: checkout_existing_branch
       continue-on-error: true
       run: |
-        git switch -c g${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
+        git switch -c ${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
     - name: Checkout the non-existent content branch
       if: ${{ steps.checkout_existing_branch.outcome == 'failure'  }}
       run: |
-        git switch -c g${{ env.CONTENT_BRANCH }}
+        git switch -c ${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Update the content manifest and push a commit to a new branch
     runs-on: ubuntu-latest
     env:
-      CONTENT_BRANCH: gh-actions/update-content-manifest-test
+      CONTENT_BRANCH: gh-actions/update-content-manifest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Update the content manifest and push a commit to a new branch
     runs-on: ubuntu-latest
     env:
-      CONTENT_BRANCH: gh-actions/update-content-manifest-debug
+      CONTENT_BRANCH: gh-actions/update-content-manifest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -49,7 +49,7 @@ jobs:
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add data/content-manifests/production.yaml
         git commit -m "Update corpora SHAs ${{ env.CONTENT_BRANCH }}"
-        git push
+        git push --set-upstream origin ${{ env.CONTENT_BRANCH }}
     # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
     # [√] Allow GitHub Actions to create and approve pull requests
     # NOTE: Only runs when changes have been pushed

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -53,7 +53,7 @@ jobs:
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add data/content-manifests/production.yaml
         git commit -m "Update corpora SHAs `date -I`"
-        git push --set-upstream origin ${{ env.CONTENT_BRANCH }}
+        git push origin ${{ env.CONTENT_BRANCH }}
     # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
     # [√] Allow GitHub Actions to create and approve pull requests
     # NOTE: Only runs when changes have been pushed

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -25,9 +25,13 @@ jobs:
     - run: pip install pip wheel --upgrade
     - name: Install scaife-cli and dependencies
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
-    - name: Checkout a new branch
+    - name: Checkout the content branch
       run: |
         git checkout -B ${{ env.CONTENT_BRANCH }}
+    - name: Pull changes from the named remote branch
+      continue-on-error: true
+      run: |
+        git pull origin gh-actions/update-content-manifest -ff
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -2,6 +2,10 @@ name: Update content manifest
 
 on:
   workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # NOTE: See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    - cron:  '0 12 * * *'
 
 jobs:
   update-content-manifest:
@@ -33,6 +37,7 @@ jobs:
         git diff --quiet data/content-manifests/
     # NOTE: manifest_has_changes returns a non-zero code if there are changes
     # commit_and_push will only run if the previous step fails (e.g., there are changes)
+    # TODO: Prevent overlapping branches; e.g. 2023-06-27, 2023-06-28, etc
     - name: Commit and push new branch
       id: commit_and_push
       if: ${{ steps.manifest_has_changes.conclusion == 'failure'  }}

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -25,10 +25,15 @@ jobs:
     - run: pip install pip wheel --upgrade
     - name: Install scaife-cli and dependencies
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
-    - name: Checkout the content branch
+    - name: Fetch branches
+      run: git fetch
+    - name: Checkout the existing content branch
+      continue-on-error: true
       run: |
-        git fetch
         git switch -c g${{ env.CONTENT_BRANCH }} --track origin/${{ env.CONTENT_BRANCH }}
+    - name: Checkout the non-existent content branch
+      run: |
+        git switch -c g${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
       env:

--- a/.github/workflows/update-content-manifest.yml
+++ b/.github/workflows/update-content-manifest.yml
@@ -17,13 +17,24 @@ jobs:
     - run: pip install pip wheel --upgrade
     - name: Install scaife-cli and dependencies
       run: pip install "scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core" PyGithub
+    - name: Create content branch env var
+      run: |
+        echo "CONTENT_BRANCH=content-`date -I`" >> "$GITHUB_ENV"
+    - name: Checkout a new branch
+      run: |
+        git checkout -b ${{ env.CONTENT_BRANCH }}
     - name: Update content manifest
       run: scaife update-manifest --github-access-token=$GITHUB_TOKEN
-    # TODO: Commit to a new branch and open a PR
-    - name: Commit and push
+    - name: Commit and push new branch
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add data/content-manifests/production.yaml
-        git commit -m "Update corpora SHAs"
+        git commit -m "Update corpora SHAs ${{ env.CONTENT_BRANCH }}"
         git push
+    # NOTE: Requires change at https://github.com/scaife-viewer/scaife-viewer/settings/actions
+    # [√] Allow GitHub Actions to create and approve pull requests
+    - name: Create pull request
+      run: gh pr create --fill
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile-elasticsearch
+++ b/Dockerfile-elasticsearch
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.21
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.10
 # analysis-icu plugin required by index template
 RUN bin/elasticsearch-plugin install analysis-icu

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ After deploying to scaife.perseus.org, manually create a new release:
     It can be created manually via:
 
     ```shell
-    python sv_pdl/stats/management/commands/diff_corpora_contents.py > diff.patch
+    scaife diff-corpora-contents > diff.patch
     cat diff.patch | pbcopy
     ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We'll ingest a portion of the data into ElasticSearch
 
 - Fetch the ElasticSearch template:
 ```shell
-curl -O https://gist.githubusercontent.com/jacobwegner/68e538edf66539feb25786cc3c9cc6c6/raw/3d17cde6a72d4526aa15fe79a07265c6638dd71c/scaife-viewer-tmp.json
+curl -O https://gist.githubusercontent.com/jacobwegner/68e538edf66539feb25786cc3c9cc6c6/raw/252e01a4c7e633b4663777a7e12dcb81119131e1/scaife-viewer-tmp.json
 ```
 - Install the template:
 ```shell

--- a/README.md
+++ b/README.md
@@ -410,39 +410,8 @@ After deploying to scaife.perseus.org, manually create a new release:
     - Description:
         - Code feature 1
         - Code feature 2, etc
-        - Content changes since the last deployment (see sample below \*)
-
-    \* TODO: Add a workflow to generate the content changes diff.
-
-    It can be created manually via:
-
-    ```shell
-    scaife diff-corpora-contents > diff.patch
-    cat diff.patch | pbcopy
-    ```
-
-    resulting in:
-
-    ```diff
-    --- old.json	2023-07-06 08:30:12
-    +++ new.json	2023-07-06 08:30:12
-    @@ -1527,10 +1527,10 @@
-        ]
-    },
-    {
-    -    "ref": "0.0.5350070018",
-    +    "ref": "0.0.5426028119",
-        "repo": "PerseusDL/canonical-greekLit",
-    -    "sha": "593087513cb16dd02f0a7b8362519a3a0e2f29bc",
-    -    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5350070018",
-    +    "sha": "701d7470d6bf9a11fb6e508ddd3270bf88748303",
-    +    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5426028119",
-        "texts": [
-        "urn:cts:greekLit:tlg0001.tlg001.perseus-grc2",
-        "urn:cts:greekLit:tlg0003.tlg001.opp-fre1",
-    \ No newline at end of file
-    ```
--
+        - Content changes since the last deployment
+        (To generate a diff, use the "Diff corpora contents" workflow documented below in ["Release Tasks"](#release-tasks))
 
 2. Save the release as a draft
 3. After verifying changes on [scaife-dev.perseus.org](https://scaife-dev.perseus.org) and promoting changes to [scaife.perseus.org](https://scaife.perseus.org), publish the draft
@@ -463,6 +432,43 @@ heroku ps:restart --app=scaife.perseus.org
 After the application restarts, refresh the homepage to verify the latest release is linked:
 
 <img width="752" alt="image" src="https://github.com/scaife-viewer/scaife-viewer/assets/629062/f905769f-49d1-405e-8f76-159aea468a0f">
+
+## Release Tasks
+
+- [Diff corpora contents](https://github.com/scaife-viewer/scaife-viewer/actions/workflows/workflows/diff-corpora-contents.yml):
+
+    Diff two versions of the corpus-metadata manifest.
+
+    This workflow should be ran after deploying to `scaife-perseus-org-dev` and before deploying to `scaife-perseus-org`.
+
+    It uses the `scaife` CLI to create a diff:
+
+
+    ```shell
+    scaife diff-corpora-contents
+    ```
+
+    If the workflow is succesful, the diff will be included in the job summary:
+
+    ```diff
+    --- old.json	2023-07-06 08:30:12
+    +++ new.json	2023-07-06 08:30:12
+    @@ -1527,10 +1527,10 @@
+        ]
+    },
+    {
+    -    "ref": "0.0.5350070018",
+    +    "ref": "0.0.5426028119",
+        "repo": "PerseusDL/canonical-greekLit",
+    -    "sha": "593087513cb16dd02f0a7b8362519a3a0e2f29bc",
+    -    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5350070018",
+    +    "sha": "701d7470d6bf9a11fb6e508ddd3270bf88748303",
+    +    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5426028119",
+        "texts": [
+        "urn:cts:greekLit:tlg0001.tlg001.perseus-grc2",
+        "urn:cts:greekLit:tlg0003.tlg001.opp-fre1",
+    \ No newline at end of file
+    ```
 
 ## Maintenance Tasks
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ For Heroku deployments, this is currently accomplished by preparing a tarball ma
 
 ## Build / Deploy Pipeline
 
-The production instance of the application is built using [GitHub Actions](https://github.com/features/actions)
+The production instance of the application is built using [GitHub Actions](https://github.com/features/actions).
 
 To deploy a new version, trigger the following GitHub Actions workflows:
 - [Update content manifest](https://github.com/scaife-viewer/scaife-viewer/actions/workflows/update-content-manifest.yml): _(optional)_
@@ -398,6 +398,8 @@ To deploy a new version, trigger the following GitHub Actions workflows:
 After verifying the changes on [scaife-dev.perseus.org](https://scaife-dev.perseus.org), re-run "Deploy app image" and "Promote search index" with:
 - Heroku app: `scaife-perseus-org`
 - Name of the latest search index: (`$ELASTICSEARCH_INDEX_NAME`) from the "Reindex content" workflow.
+
+Additional [maintenance tasks](#maintenance-tasks) are documented below.
 
 ## GitHub releases
 
@@ -461,3 +463,15 @@ heroku ps:restart --app=scaife.perseus.org
 After the application restarts, refresh the homepage to verify the latest release is linked:
 
 <img width="752" alt="image" src="https://github.com/scaife-viewer/scaife-viewer/assets/629062/f905769f-49d1-405e-8f76-159aea468a0f">
+
+## Maintenance Tasks
+
+The following GitHub Actions workflows are used to run maintenance tasks:
+
+- [Delete indices](https://github.com/scaife-viewer/scaife-viewer/actions/workflows/delete-indices.yml):
+
+    This workflow should be ran after promoting the search index.
+
+    It will remove _all_ indices _except_ for the current active index (`$ELASTICSEARCH_INDEX_NAME` as configured for the `scaife-perseus-org` Heroku app).
+
+    This _could_ be a scheduled workflow, but was kept as a manual task in case there was a need to have multiple indices available (for testing on `scaife-perseus-org-dev`, etc.)

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5814937852
-  sha: b89513c745d1a45adc0473c31529bbff4068d22b
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5814937852
+  ref: 0.0.5827463254
+  sha: a4cb012b4d7043ebb8044cfca098ba33f51ec14e
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5827463254
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -1,7 +1,7 @@
 PerseusDL/canonical-latinLit:
-  ref: 0.0.5510581333
-  sha: 8049f6ed333472e4fe57bb6bddfdee225d85a548
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5510581333
+  ref: 0.0.5555744551
+  sha: 3bb4fa9659f512efc73c42c37a9fc1d197c74c75
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5555744551
 PerseusDL/canonical-greekLit:
   ref: 0.0.5512790891
   sha: 492b863036e56d0938798fb231e2d5af033af0a6

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 4493548c8e78a88e6e28459b2ed4490d533683fa
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5328305771
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5426028119
-  sha: 701d7470d6bf9a11fb6e508ddd3270bf88748303
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5426028119
+  ref: 0.0.5497605357
+  sha: 586a2f94494d407023205d938e98bee2bdff9ee0
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5497605357
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: fe3cc98de6d457e78fd2bce105fe91d3fab45db1
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5580293955
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5578335521
-  sha: bcd6717229774d9e5a84f2da745f8e66169ae8b7
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5578335521
+  ref: 0.0.5615729496
+  sha: 34c764febea8917139846f548d5b85e1886995b2
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5615729496
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5803675065
-  sha: 3f59751e7d2d86a33c782336f64b26e17305127e
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5803675065
+  ref: 0.0.5814937852
+  sha: b89513c745d1a45adc0473c31529bbff4068d22b
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5814937852
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -19,9 +19,9 @@ PerseusDL/canonical-pdlpsci:
   sha: 72f6ce7dc6e3b783a063baed4c1539302e3b9247
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-pdlpsci/tarball/v0.3.0
 OpenGreekAndLatin/First1KGreek:
-  ref: 1.1.5764935493
-  sha: 9ec480cd09c374519dc094a759f274c285c29acc
-  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5764935493
+  ref: 1.1.5810935620
+  sha: 04a8d22471e9e8dfc7e6ac2e2cac601c82d92bf5
+  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5810935620
 OpenGreekAndLatin/Latin:
   ref: v1.14.0
   sha: 9a3e833b515adad490bdd11977eaf1a84d24b246

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5615729496
-  sha: 34c764febea8917139846f548d5b85e1886995b2
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5615729496
+  ref: 0.0.5788349777
+  sha: 842e08ee2f4a34a4a27dda1ab4ba7e0443edcd9b
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5788349777
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f
@@ -19,9 +19,9 @@ PerseusDL/canonical-pdlpsci:
   sha: 72f6ce7dc6e3b783a063baed4c1539302e3b9247
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-pdlpsci/tarball/v0.3.0
 OpenGreekAndLatin/First1KGreek:
-  ref: 1.1.5738462508
-  sha: 44e59e3b3e930d3d3ccef15e10683fc82cb8453d
-  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5738462508
+  ref: 1.1.5764935493
+  sha: 9ec480cd09c374519dc094a759f274c285c29acc
+  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5764935493
 OpenGreekAndLatin/Latin:
   ref: v1.14.0
   sha: 9a3e833b515adad490bdd11977eaf1a84d24b246

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5788349777
-  sha: 842e08ee2f4a34a4a27dda1ab4ba7e0443edcd9b
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5788349777
+  ref: 0.0.5803675065
+  sha: 3f59751e7d2d86a33c782336f64b26e17305127e
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5803675065
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -1,11 +1,11 @@
 PerseusDL/canonical-latinLit:
-  ref: 0.0.5328305771
-  sha: 4493548c8e78a88e6e28459b2ed4490d533683fa
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5328305771
+  ref: 0.0.5510581333
+  sha: 8049f6ed333472e4fe57bb6bddfdee225d85a548
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5510581333
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5497605357
-  sha: 586a2f94494d407023205d938e98bee2bdff9ee0
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5497605357
+  ref: 0.0.5512790891
+  sha: 492b863036e56d0938798fb231e2d5af033af0a6
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5512790891
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 4493548c8e78a88e6e28459b2ed4490d533683fa
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5328305771
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5350070018
-  sha: 593087513cb16dd02f0a7b8362519a3a0e2f29bc
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5350070018
+  ref: 0.0.5426028119
+  sha: 701d7470d6bf9a11fb6e508ddd3270bf88748303
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5426028119
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -1,7 +1,7 @@
 PerseusDL/canonical-latinLit:
-  ref: 0.0.5580293955
-  sha: fe3cc98de6d457e78fd2bce105fe91d3fab45db1
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5580293955
+  ref: 0.0.5672213309
+  sha: ea314da0bb204b3679bc672709fad6c6d8a94952
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5672213309
 PerseusDL/canonical-greekLit:
   ref: 0.0.5615729496
   sha: 34c764febea8917139846f548d5b85e1886995b2
@@ -19,9 +19,9 @@ PerseusDL/canonical-pdlpsci:
   sha: 72f6ce7dc6e3b783a063baed4c1539302e3b9247
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-pdlpsci/tarball/v0.3.0
 OpenGreekAndLatin/First1KGreek:
-  ref: 1.1.5328298963
-  sha: 736ca20351a9c478829e150a47a95fae5a1e6992
-  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5328298963
+  ref: 1.1.5672597736
+  sha: d05511fbd2f2a6e4628d2fc352e68636a295110c
+  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5672597736
 OpenGreekAndLatin/Latin:
   ref: v1.14.0
   sha: 9a3e833b515adad490bdd11977eaf1a84d24b246

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -1,11 +1,11 @@
 PerseusDL/canonical-latinLit:
-  ref: 0.0.5555744551
-  sha: 3bb4fa9659f512efc73c42c37a9fc1d197c74c75
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5555744551
+  ref: 0.0.5580293955
+  sha: fe3cc98de6d457e78fd2bce105fe91d3fab45db1
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5580293955
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5512790891
-  sha: 492b863036e56d0938798fb231e2d5af033af0a6
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5512790891
+  ref: 0.0.5578335521
+  sha: bcd6717229774d9e5a84f2da745f8e66169ae8b7
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5578335521
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -1,7 +1,7 @@
 PerseusDL/canonical-latinLit:
-  ref: 0.0.5672213309
-  sha: ea314da0bb204b3679bc672709fad6c6d8a94952
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5672213309
+  ref: 0.0.5728893694
+  sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
   ref: 0.0.5615729496
   sha: 34c764febea8917139846f548d5b85e1886995b2
@@ -19,9 +19,9 @@ PerseusDL/canonical-pdlpsci:
   sha: 72f6ce7dc6e3b783a063baed4c1539302e3b9247
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-pdlpsci/tarball/v0.3.0
 OpenGreekAndLatin/First1KGreek:
-  ref: 1.1.5672597736
-  sha: d05511fbd2f2a6e4628d2fc352e68636a295110c
-  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5672597736
+  ref: 1.1.5738462508
+  sha: 44e59e3b3e930d3d3ccef15e10683fc82cb8453d
+  tarball_url: https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5738462508
 OpenGreekAndLatin/Latin:
   ref: v1.14.0
   sha: 9a3e833b515adad490bdd11977eaf1a84d24b246

--- a/data/content-manifests/production.yaml
+++ b/data/content-manifests/production.yaml
@@ -3,9 +3,9 @@ PerseusDL/canonical-latinLit:
   sha: 5d4237e6c5b5d14a6e82719a4fdacd55c1cf7520
   tarball_url: https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.5728893694
 PerseusDL/canonical-greekLit:
-  ref: 0.0.5827463254
-  sha: a4cb012b4d7043ebb8044cfca098ba33f51ec14e
-  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5827463254
+  ref: 0.0.5838365674
+  sha: a06c0586e1f497ce28343ff0149fa7989d0ac4f8
+  tarball_url: https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.5838365674
 OpenGreekAndLatin/csel-dev:
   ref: 0.0.3678995538
   sha: 3f8969d102e18621edd165d5edaa72891477e74f

--- a/deploy/artifacts/prepare-artifacts.dockerfile
+++ b/deploy/artifacts/prepare-artifacts.dockerfile
@@ -2,7 +2,7 @@ ARG WEBAPP_DOCKER_IMAGE="docker.io/scaife-viewer/scaife-viewer/webapp-base:lates
 
 FROM $WEBAPP_DOCKER_IMAGE as artifacts
 WORKDIR /opt/scaife-viewer/src/
-COPY data/content-manifests .
+COPY data/content-manifests/ .
 RUN python manage.py load_text_repos \
     && python manage.py slim_text_repos \
     && python manage.py shell -c 'from scaife_viewer.core.cts import text_inventory; text_inventory();'

--- a/deploy/artifacts/prepare-artifacts.dockerfile
+++ b/deploy/artifacts/prepare-artifacts.dockerfile
@@ -2,7 +2,7 @@ ARG WEBAPP_DOCKER_IMAGE="docker.io/scaife-viewer/scaife-viewer/webapp-base:lates
 
 FROM $WEBAPP_DOCKER_IMAGE as artifacts
 WORKDIR /opt/scaife-viewer/src/
-COPY data/content-manifests/ .
+COPY ./data/content-manifests .
 RUN python manage.py load_text_repos \
     && python manage.py slim_text_repos \
     && python manage.py shell -c 'from scaife_viewer.core.cts import text_inventory; text_inventory();'

--- a/deploy/artifacts/prepare-artifacts.dockerfile
+++ b/deploy/artifacts/prepare-artifacts.dockerfile
@@ -2,6 +2,7 @@ ARG WEBAPP_DOCKER_IMAGE="docker.io/scaife-viewer/scaife-viewer/webapp-base:lates
 
 FROM $WEBAPP_DOCKER_IMAGE as artifacts
 WORKDIR /opt/scaife-viewer/src/
+COPY data/content-manifests .
 RUN python manage.py load_text_repos \
     && python manage.py slim_text_repos \
     && python manage.py shell -c 'from scaife_viewer.core.cts import text_inventory; text_inventory();'

--- a/deploy/search-index/search-index.dockerfile
+++ b/deploy/search-index/search-index.dockerfile
@@ -1,5 +1,5 @@
-ARG WEBAPP_DOCKER_IMAGE="docker.io/scaife-viewer/scaife-viewer/webapp-deploy:latest"
-FROM $WEBAPP_DOCKER_IMAGE as data-prep
+ARG WEBAPP_DEPLOY_DOCKER_IMAGE="docker.io/scaife-viewer/scaife-viewer/webapp-deploy:latest"
+FROM $WEBAPP_DEPLOY_DOCKER_IMAGE as data-prep
 
 ARG ANNOTATIONS_TARBALL="https://github.com/scaife-viewer/ogl-pdl-annotations/tarball/main"
 RUN mkdir -p /opt/scaife-viewer/src/data/search-annotations

--- a/deploy/webapp/webapp-deploy.dockerfile
+++ b/deploy/webapp/webapp-deploy.dockerfile
@@ -12,6 +12,7 @@ RUN apk add bash
 RUN ./bin/fetch_corpus_config
 RUN ./bin/copy_corpus_repo_metadata
 
+ARG GITHUB_ACCESS_TOKEN=""
 RUN python manage.py prepare_atlas_db --force
 
 # https://stackoverflow.com/a/54245466

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pinax-eventlog[django-lts]==5.1.0
 pinax-theme-bootstrap==8.0.1
 pinax-webanalytics==4.0.2
 psycopg2-binary==2.8.6
-PyYAML==5.4.1
+PyYAML==6.0.1
 raven==6.10.0
 requests==2.22.0
 # @@@ atlas package is not yet released to pypi

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ django-letsencrypt==3.0.1
 django-oidc-provider==0.7.0
 django-user-accounts==3.0.2
 django-webpack-loader==0.6.0
+# NOTE: Pinned at 7.10.x;
+# refs https://bonsai.io/docs/which-versions-bonsai-supports
+elasticsearch==7.10.1
 Django==2.2.28
 gunicorn==19.9.0
 honcho==1.0.1
@@ -21,6 +24,6 @@ requests==2.22.0
 # @@@ atlas package is not yet released to pypi
 scaife-viewer-atlas @https://github.com/scaife-viewer/backend/archive/scaife-viewer-atlas@0.1a15.zip#subdirectory=atlas
 # @@@ core package is not yet released to pypi
-scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/8ca4c2e2328a7deaeb41fa3f388943d1a4c24328.zip#subdirectory=core
+scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/60513f33fa67e8d28f512841622970f38933ddb3.zip#subdirectory=core
 six==1.12.0
 whitenoise==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ requests==2.22.0
 # @@@ atlas package is not yet released to pypi
 scaife-viewer-atlas @https://github.com/scaife-viewer/backend/archive/scaife-viewer-atlas@0.1a15.zip#subdirectory=atlas
 # @@@ core package is not yet released to pypi
-scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/10e66fc47f36a308f8cdcd1a2c84344ae2cdd23e.zip#subdirectory=core
+scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/8ca4c2e2328a7deaeb41fa3f388943d1a4c24328.zip#subdirectory=core
 six==1.12.0
 whitenoise==4.1.2

--- a/sv_pdl/changelog/keyfile.py
+++ b/sv_pdl/changelog/keyfile.py
@@ -1,3 +1,3 @@
 cachekeys = {
-    "LATEST_CHANGELOG": "latest-changelog"
+    "LATEST_RELEASE": "latest-release"
 }

--- a/sv_pdl/management/commands/cleanup_search_indices.py
+++ b/sv_pdl/management/commands/cleanup_search_indices.py
@@ -1,0 +1,43 @@
+from django.core.management.base import BaseCommand, CommandParser
+from django.conf import settings
+
+from scaife_viewer.core.search import get_es_client as elasticsearch_client
+
+
+class Command(BaseCommand):
+    """
+    Cleans up old search indices
+    """
+
+    help = "Cleans up old search indices"
+
+    def add_arguments(self, parser: CommandParser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            dest="force",
+            default=False,
+            help="Force deletion (no prompt).",
+        )
+
+    def handle(self, *args, **options):
+        force = options["force"]
+        es = elasticsearch_client()
+        idx = settings.ELASTICSEARCH_INDEX_NAME
+        self.stdout.write(f"Primary index: {idx}")
+        all_indices = set([i for i in es.indices.get("*").keys()])
+        assert idx in all_indices
+        to_delete = all_indices.difference({idx})
+        if to_delete:
+            deletes_string = "\n\t".join(to_delete)
+            self.stdout.write(f"Indices to delete:\n {deletes_string}")
+            delete_indices = force or input("Delete indices? [y/n]\n") == "y"
+            if delete_indices:
+                deleted = es.indices.delete(index=",".join(to_delete))
+                assert deleted
+                self.stdout.write(f"Indices deleted: {len(to_delete)} ")
+        else:
+            self.stdout.write("No indices to delete")
+
+        current_indices = set([i for i in es.indices.get("*").keys()])
+        assert set([idx]) == current_indices

--- a/sv_pdl/templates/homepage.html
+++ b/sv_pdl/templates/homepage.html
@@ -49,7 +49,7 @@
     <div class="container">
 
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-8 offset-md-2">
           <h2>About the Scaife Viewer</h2>
           <p class="lead">
             The <b>Scaife Viewer</b> is a reading environment for pre-modern text
@@ -60,28 +60,11 @@
           <p class="more">
             <a href="{% url 'about' %}">read more</a>
           </p>
-        </div>
-        <div class="col-md-6">
-          <h2>Recent Changes</h2>
-
-          {% for entry in changelog %}
-
-          <h3>{{ entry.title }}</h3>
-
-          {{ entry.body|safe }}
-
-          <div class="ml-4">
-            <a href="{{ entry.release_url }}">
-            <small>
-              ({{ entry.release_tag }} release)
-            </small>
-            </a>
-          </div>
-          {% if not forloop.last %}
-          <hr />
+          {% if release %}
+          <small>
+            Latest release: <a target="_blank" href="{{ release.url }}">{{ release.title }}</a>
+          </small>
           {% endif %}
-
-          {% endfor %}
 
         </div>
       </div>

--- a/sv_pdl/views.py
+++ b/sv_pdl/views.py
@@ -2,28 +2,38 @@ from django.core.cache import cache
 from django.db.models import Count
 from django.shortcuts import render
 
+from github import Github
 from scaife_viewer.atlas.models import Repo
 
 from .changelog.keyfile import cachekeys
-from .changelog.models import ChangelogEntry
 from .stats import get_library_stats
 
 
 CACHE_FOREVER = None
-LATEST_CHANGELOG_KEY = cachekeys["LATEST_CHANGELOG"]
+LATEST_RELEASE_KEY = cachekeys["LATEST_RELEASE"]
+
+
+def _latest_release():
+    try:
+        client = Github()
+        repo = client.get_repo("scaife-viewer/scaife-viewer")
+        release = release = next(iter(repo.get_releases()))
+        return {"title": release.title, "url": release.html_url}
+    except Exception:
+        return {}
 
 
 def home(request):
-    changelog = cache.get(LATEST_CHANGELOG_KEY, None)
-    if not changelog:
-        changelog = ChangelogEntry.objects.order_by("-timestamp")[0:3]
-        cache.set(LATEST_CHANGELOG_KEY, changelog, CACHE_FOREVER)
+    release = cache.get(LATEST_RELEASE_KEY, None)
+    if not release:
+        release = _latest_release()
+        cache.set(LATEST_RELEASE_KEY, release, CACHE_FOREVER)
     return render(
         request,
         "homepage.html",
         {
             "stats": get_library_stats(),
-            "changelog": changelog,
+            "release": release,
         },
     )
 


### PR DESCRIPTION
Follows #566.

Rewrites manual scripts accessible only by @jacobwegner into GitHub actions.

TODOS:
- [x] Document each workflow
- [x] Make workables composable (e.g., don't assume "latest")
- [x] Make PRs for content updates or use an objectstore (rather than depending on Git commits to the default branch)
- [x] Replace changelog with GitHub releases API
- [x] Create workflow to promote search index
- [x] Create wrappers for the remaining portions of `pipeline.sh`:
- [x] Test `diff-corpora-contents` during next deploy

Will continue in https://github.com/scaife-viewer/scaife-viewer/issues/623