### PR TITLE
Upgrade to ElasticSearch 7

### DIFF
--- a/Dockerfile-elasticsearch
+++ b/Dockerfile-elasticsearch
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.21
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.10
 # analysis-icu plugin required by index template
 RUN bin/elasticsearch-plugin install analysis-icu

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We'll ingest a portion of the data into ElasticSearch
 
 - Fetch the ElasticSearch template:
 ```shell
-curl -O https://gist.githubusercontent.com/jacobwegner/68e538edf66539feb25786cc3c9cc6c6/raw/3d17cde6a72d4526aa15fe79a07265c6638dd71c/scaife-viewer-tmp.json
+curl -O https://gist.githubusercontent.com/jacobwegner/68e538edf66539feb25786cc3c9cc6c6/raw/252e01a4c7e633b4663777a7e12dcb81119131e1/scaife-viewer-tmp.json
 ```
 - Install the template:
 ```shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ requests==2.22.0
 # @@@ atlas package is not yet released to pypi
 scaife-viewer-atlas @https://github.com/scaife-viewer/backend/archive/scaife-viewer-atlas@0.1a15.zip#subdirectory=atlas
 # @@@ core package is not yet released to pypi
-scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/8ca4c2e2328a7deaeb41fa3f388943d1a4c24328.zip#subdirectory=core
+scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/e2915ad35f190c8c42bdb6475c2299abc3082668.zip#subdirectory=core
 six==1.12.0
 whitenoise==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ django-letsencrypt==3.0.1
 django-oidc-provider==0.7.0
 django-user-accounts==3.0.2
 django-webpack-loader==0.6.0
+# NOTE: Pinned at 7.10.x;
+# refs https://bonsai.io/docs/which-versions-bonsai-supports
+elasticsearch==7.10.1
 Django==2.2.28
 gunicorn==19.9.0
 honcho==1.0.1
@@ -21,6 +24,6 @@ requests==2.22.0
 # @@@ atlas package is not yet released to pypi
 scaife-viewer-atlas @https://github.com/scaife-viewer/backend/archive/scaife-viewer-atlas@0.1a15.zip#subdirectory=atlas
 # @@@ core package is not yet released to pypi
-scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/e2915ad35f190c8c42bdb6475c2299abc3082668.zip#subdirectory=core
+scaife-viewer-core @https://github.com/scaife-viewer/backend/archive/60513f33fa67e8d28f512841622970f38933ddb3.zip#subdirectory=core
 six==1.12.0
 whitenoise==4.1.2


### PR DESCRIPTION
Adds support for ElasticSearch 7.

## Deployment Steps
- [x] Create an ElasticSearch 7 cluster using Bonsai:
```shell
 heroku addons:create bonsai:standard-sm -a scaife-perseus-org --version=7.10.2 --as=ELASTICSEARCH_B
```
- [x] Create a credential for `scaife-perseus-org-dev` and update ELASTICSEARCH_URL:
```shell
heroku config:set ELASTICSEARCH_URL=<credential> -a scaife-perseus-org-dev
```
- [x] Add the new search index template
```shell
curl -X PUT "<credential>/_template/scaife-viewer?pretty" -H 'Content-Type: application/json' -d "$(cat scaife-viewer-tmp.json)"
```
- [x] Update the Google Cloud Run task with the new credential
- [x] Re-build base, artifacts, deployment and search index images for ES 7
- [x] Re-index content for ES 7
- [x] Verify on scaife-perseus-org-dev
- [x] Promote changes on scaife-perseus-org
- [x] Optional: Update the attachment alias on scaife-perseus-org
